### PR TITLE
Uplink: envío a lora-app-server del campo FineTimestamp recibido

### DIFF
--- a/internal/api/as/as.go
+++ b/internal/api/as/as.go
@@ -355,7 +355,12 @@ func (a *ApplicationServerAPI) HandleUplinkData(ctx context.Context, req *as.Han
 			row.Name = gw.Name
 		}
 
-		if rxInfo.Time != nil {
+		if fts := rxInfo.GetPlainFineTimestamp(); fts != nil {
+			row.FineTimestamp = fts.Time
+			ns64 := int64(fts.Time.Nanos)
+			ts := time.Unix(fts.Time.Seconds, ns64)
+			row.Time = &ts
+		} else if rxInfo.Time != nil {
 			ts, err := ptypes.Timestamp(rxInfo.Time)
 			if err != nil {
 				log.WithField("dev_eui", devEUI).WithError(err).Error("parse timestamp error")

--- a/internal/integration/models.go
+++ b/internal/integration/models.go
@@ -4,6 +4,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"time"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 
 	"github.com/brocaar/lorawan"
 	"github.com/gofrs/uuid"
@@ -27,13 +28,14 @@ type Location struct {
 
 // RXInfo contains the RX information.
 type RXInfo struct {
-	GatewayID lorawan.EUI64 `json:"gatewayID"`
-	UplinkID  uuid.UUID     `json:"uplinkID"`
-	Name      string        `json:"name"`
-	Time      *time.Time    `json:"time,omitempty"`
-	RSSI      int           `json:"rssi"`
-	LoRaSNR   float64       `json:"loRaSNR"`
-	Location  *Location     `json:"location"`
+	GatewayID 		lorawan.EUI64 			`json:"gatewayID"`
+	UplinkID  		uuid.UUID     			`json:"uplinkID"`
+	Name      		string        			`json:"name"`
+	Time      		*time.Time    			`json:"time,omitempty"`
+	FineTimestamp	*timestamp.Timestamp	`json:"fineTimestamp,omitempty"`
+	RSSI      		int           			`json:"rssi"`
+	LoRaSNR   		float64       			`json:"loRaSNR"`
+	Location  		*Location     			`json:"location"`
 }
 
 // TXInfo contains the TX information.


### PR DESCRIPTION
Hello,

I've noted that loraserver doesn't send FineTimestamp info (received from V2 gateway) to lora-app-server. That info is needed on my integrated app (by http)
I'm a java developer and I have not so much experience on go languaje. However, the changes included on this pull request works fine.
Could you check this review and tell me if I am wrong? Feel free of make the changes you need.

Thanks.