### PR TITLE
Add rpm generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ nfpm:
   license: MIT
   formats:
     - deb
+    - rpm
   bindir: /usr/bin
   files:
     "packaging/files/chirpstack-application-server.rotate": "/etc/logrotate.d/chirpstack-application-server"

--- a/docs/content/overview/downloads.md
+++ b/docs/content/overview/downloads.md
@@ -50,6 +50,17 @@ sudo echo "deb https://artifacts.chirpstack.io/packages/3.x/deb stable main" | s
 sudo apt-get update
 {{< /highlight >}}
 
+## Redhat / Centos packages
+
+| File name                                                                                                                                                                              | OS      | Arch  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------- | ----- |
+| [chirpstack-application-server_{{< version >}}_linux_386.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-application-server/chirpstack-application-server_{{< version >}}_linux_386.rpm)     | Linux   | 386   |
+| [chirpstack-application-server_{{< version >}}_linux_amd64.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-application-server/chirpstack-application-server_{{< version >}}_linux_amd64.rpm) | Linux   | amd64 |
+| [chirpstack-application-server_{{< version >}}_linux_armv5.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-application-server/chirpstack-application-server_{{< version >}}_linux_armv5.rpm) | Linux   | arm   |
+| [chirpstack-application-server_{{< version >}}_linux_armv6.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-application-server/chirpstack-application-server_{{< version >}}_linux_armv6.rpm) | Linux   | arm   |
+| [chirpstack-application-server_{{< version >}}_linux_armv7.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-application-server/chirpstack-application-server_{{< version >}}_linux_armv7.rpm) | Linux   | arm   |
+| [chirpstack-application-server_{{< version >}}_linux_arm64.rpm](https://artifacts.chirpstack.io/downloads/chirpstack-application-server/chirpstack-application-server_{{< version >}}_linux_arm64.rpm) | Linux   | arm64 |
+
 ### Docker images
 
 For Docker images, please refer to https://hub.docker.com/r/chirpstack/chirpstack-application-server/.


### PR DESCRIPTION
- Add rpm to .goreleaser.yml
- Add rpm download links to downloads page

I did test only the amd64 version and I do not know if other versions will be released and functional.