### PR TITLE
API bug: Parameter "UpdatedAt" is not modified

### DIFF
--- a/internal/storage/organization.go
+++ b/internal/storage/organization.go
@@ -318,7 +318,8 @@ func UpdateOrganizationUser(ctx context.Context, db sqlx.Execer, organizationID,
 		set
 			is_admin = $3,
 			is_device_admin = $4,
-			is_gateway_admin = $5
+			is_gateway_admin = $5,
+			updated_at = now()
 		where
 			organization_id = $1
 			and user_id = $2


### PR DESCRIPTION
executing PUT request to below API for modify user details for the particular organization "UpdatedAt" field is not modified

/API/organizations/{organization_user.organization_id}/users/{organization_user.user_id}