### PR TITLE
add kafka integration

### DIFF
--- a/cmd/chirpstack-application-server/cmd/configfile.go
+++ b/cmd/chirpstack-application-server/cmd/configfile.go
@@ -203,6 +203,7 @@ id="{{ .ApplicationServer.ID }}"
   # * aws_sns           - AWS Simple Notification Service (SNS)
   # * azure_service_bus - Azure Service-Bus
   # * gcp_pub_sub       - Google Cloud Pub/Sub
+  # * kafka             - Kafka distributed streaming platform
   # * postgresql        - PostgreSQL database
   enabled=[{{ if .ApplicationServer.Integration.Enabled|len }}"{{ end }}{{ range $index, $elm := .ApplicationServer.Integration.Enabled }}{{ if $index }}", "{{ end }}{{ $elm }}{{ end }}{{ if .ApplicationServer.Integration.Enabled|len }}"{{ end }}]
 
@@ -356,6 +357,15 @@ id="{{ .ApplicationServer.ID }}"
 
   # Pub/Sub topic name.
   topic_name="{{ .ApplicationServer.Integration.GCPPubSub.TopicName }}"
+
+
+  # Kafka integration.
+  [application_server.integration.kafka]
+  # Brokers, e.g.: localhost:9092.
+  brokers=[{{ range $index, $broker := .ApplicationServer.Integration.Kafka.Brokers }}{{ if $index }}, {{ end }}"{{ $broker }}"{{ end }}]
+
+  # Topic for events.
+  topic="{{ .ApplicationServer.Integration.Kafka.Topic }}"
 
 
   # PostgreSQL database integration.

--- a/cmd/chirpstack-application-server/cmd/configfile.go
+++ b/cmd/chirpstack-application-server/cmd/configfile.go
@@ -367,6 +367,14 @@ id="{{ .ApplicationServer.ID }}"
   # Topic for events.
   topic="{{ .ApplicationServer.Integration.Kafka.Topic }}"
 
+  # Template for keys included in Kafka messages. If empty, no key is included.
+  # Kafka uses the key for distributing messages over partitions. You can use
+  # this to ensure some subset of messages end up in the same partition, so
+  # they can be consumed in-order. And Kafka can use the key for data retention
+  # decisions.  A header "event" with the event type is included in each
+  # message. There is no need to parse it from the key.
+  event_key_template="{{ .ApplicationServer.Integration.Kafka.EventKeyTemplate }}"
+
 
   # PostgreSQL database integration.
   [application_server.integration.postgresql]

--- a/cmd/chirpstack-application-server/cmd/root.go
+++ b/cmd/chirpstack-application-server/cmd/root.go
@@ -60,6 +60,7 @@ func init() {
 	viper.SetDefault("application_server.integration.mqtt.clean_session", true)
 	viper.SetDefault("application_server.integration.kafka.brokers", []string{"localhost:9092"})
 	viper.SetDefault("application_server.integration.kafka.topic", "chirpstack_as")
+	viper.SetDefault("application_server.integration.kafka.event_key_template", "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}")
 	viper.SetDefault("application_server.integration.postgresql.max_idle_connections", 2)
 	viper.SetDefault("application_server.integration.amqp.url", "amqp://guest:guest@localhost:5672")
 	viper.SetDefault("application_server.integration.amqp.event_routing_key_template", "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}")

--- a/cmd/chirpstack-application-server/cmd/root.go
+++ b/cmd/chirpstack-application-server/cmd/root.go
@@ -58,6 +58,8 @@ func init() {
 	viper.SetDefault("application_server.integration.mqtt.location_topic_template", "application/{{ .ApplicationID }}/device/{{ .DevEUI }}/location")
 	viper.SetDefault("application_server.integration.mqtt.tx_ack_topic_template", "application/{{ .ApplicationID }}/device/{{ .DevEUI }}/txack")
 	viper.SetDefault("application_server.integration.mqtt.clean_session", true)
+	viper.SetDefault("application_server.integration.kafka.brokers", []string{"localhost:9092"})
+	viper.SetDefault("application_server.integration.kafka.topic", "chirpstack_as")
 	viper.SetDefault("application_server.integration.postgresql.max_idle_connections", 2)
 	viper.SetDefault("application_server.integration.amqp.url", "amqp://guest:guest@localhost:5672")
 	viper.SetDefault("application_server.integration.amqp.event_routing_key_template", "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,14 @@ services:
       - redis
       - mosquitto
       - rabbitmq
+      - zookeeper
+      - kafka
     environment:
       - TEST_POSTGRES_DSN=postgres://chirpstack_as:chirpstack_as@postgres/chirpstack_as?sslmode=disable
       - TEST_REDIS_URL=redis://redis:6379
       - TEST_MQTT_SERVER=tcp://mosquitto:1883
       - TEST_RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+      - TEST_KAFKA_BROKER=kafka:9092
 
   postgres:
     image: postgres:9.6-alpine
@@ -32,3 +35,15 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-alpine
+
+  zookeeper:
+    image: 'bitnami/zookeeper:3'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'bitnami/kafka:2'
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    depends_on:
+      - zookeeper

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -419,6 +419,14 @@ id="6d5db27e-4ce2-4b2b-b5d7-91f069397978"
   # Topic for events.
   topic="chirpstack_as"
 
+  # Template for keys included in Kafka messages. If empty, no key is included.
+  # Kafka uses the key for distributing messages over partitions. You can use
+  # this to ensure some subset of messages end up in the same partition, so
+  # they can be consumed in-order. And Kafka can use the key for data retention
+  # decisions.  A header "event" with the event type is included in each
+  # message. There is no need to parse it from the key.
+  event_key_template="{{ .ApplicationServer.Integration.Kafka.EventKeyTemplate }}"
+
 
   # PostgreSQL database integration.
   [application_server.integration.postgresql]

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -411,6 +411,15 @@ id="6d5db27e-4ce2-4b2b-b5d7-91f069397978"
   topic_name=""
 
 
+  # Kafka integration.
+  [application_server.integration.kafka]
+  # Brokers, e.g.: localhost:9092.
+  brokers=["localhost:9092"]
+
+  # Topic for events.
+  topic="chirpstack_as"
+
+
   # PostgreSQL database integration.
   [application_server.integration.postgresql]
   # PostgreSQL dsn (e.g.: postgres://user:password@hostname/database?sslmode=disable).

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -256,6 +256,7 @@ id="6d5db27e-4ce2-4b2b-b5d7-91f069397978"
   # * aws_sns           - AWS Simple Notification Service (SNS)
   # * azure_service_bus - Azure Service-Bus
   # * gcp_pub_sub       - Google Cloud Pub/Sub
+  # * kafka             - Kafka distributed streaming platform
   # * postgresql        - PostgreSQL database
   enabled=["mqtt"]
 
@@ -425,7 +426,7 @@ id="6d5db27e-4ce2-4b2b-b5d7-91f069397978"
   # they can be consumed in-order. And Kafka can use the key for data retention
   # decisions.  A header "event" with the event type is included in each
   # message. There is no need to parse it from the key.
-  event_key_template="{{ .ApplicationServer.Integration.Kafka.EventKeyTemplate }}"
+  event_key_template="application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}"
 
 
   # PostgreSQL database integration.

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/robertkrimen/otto v0.0.0-20191217063420-37f8e9a2460c
 	github.com/rubenv/sql-migrate v0.0.0-20191213152630-06338513c237
+	github.com/segmentio/kafka-go v0.3.6
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mz
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
@@ -183,6 +185,8 @@ github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
@@ -282,6 +286,8 @@ github.com/kamilsk/retry/v4 v4.0.0/go.mod h1:0af33qDvzbhQqdOBi7iOjEpmP4brbPmNZpo
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.9.8 h1:VMAMUUOh+gaxKTMk+zqbjsSjsIcUcL/LF4o63i82QyA=
+github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -340,6 +346,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
+github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -387,6 +395,8 @@ github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rubenv/sql-migrate v0.0.0-20191213152630-06338513c237 h1:q6N3WgCVttyX9Fg3e4nrLohUXvAlTu44Ugc4m6qlezc=
 github.com/rubenv/sql-migrate v0.0.0-20191213152630-06338513c237/go.mod h1:rtQlpHw+eR6UrqaS3kX1VYeaCxzCVdimDS7g5Ln4pPc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/segmentio/kafka-go v0.3.6 h1:+JauPDvHurc4XSJVGniNwFuv4NmRLr1CxWvhWkRAtXA=
+github.com/segmentio/kafka-go v0.3.6/go.mod h1:8rEphJEczp+yDE/R5vwmaqZgF1wllrl4ioQcNKB8wVA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -438,6 +448,10 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
+github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
@@ -456,6 +470,7 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,8 +206,9 @@ type IntegrationAMQPConfig struct {
 
 // IntegrationKafkaConfig holds the Kafka integration configuration.
 type IntegrationKafkaConfig struct {
-	Brokers []string `mapstructure:"brokers"`
-	Topic   string   `mapstructure:"topic"`
+	Brokers          []string `mapstructure:"brokers"`
+	Topic            string   `mapstructure:"topic"`
+	EventKeyTemplate string   `mapstructure:"event_key_template"`
 }
 
 // AzurePublishMode defines the publish-mode type.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 			AzureServiceBus IntegrationAzureConfig      `mapstructure:"azure_service_bus"`
 			MQTT            IntegrationMQTTConfig       `mapstructure:"mqtt"`
 			GCPPubSub       IntegrationGCPConfig        `mapstructure:"gcp_pub_sub"`
+			Kafka           IntegrationKafkaConfig      `mapstructure:"kafka"`
 			PostgreSQL      IntegrationPostgreSQLConfig `mapstructure:"postgresql"`
 			AMQP            IntegrationAMQPConfig       `mapstructure:"amqp"`
 		} `mapstructure:"integration"`
@@ -201,6 +202,12 @@ type IntegrationPostgreSQLConfig struct {
 type IntegrationAMQPConfig struct {
 	URL                     string `mapstructure:"url"`
 	EventRoutingKeyTemplate string `mapstructure:"event_routing_key_template"`
+}
+
+// IntegrationKafkaConfig holds the Kafka integration configuration.
+type IntegrationKafkaConfig struct {
+	Brokers []string `mapstructure:"brokers"`
+	Topic   string   `mapstructure:"topic"`
 }
 
 // AzurePublishMode defines the publish-mode type.

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brocaar/chirpstack-application-server/internal/integration/gcppubsub"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/http"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/influxdb"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/kafka"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/logger"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/loracloud"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/marshaler"
@@ -80,6 +81,8 @@ func Setup(conf config.Config) error {
 			i, err = mqtt.New(marshalType, conf.ApplicationServer.Integration.MQTT)
 		case "gcp_pub_sub":
 			i, err = gcppubsub.New(marshalType, conf.ApplicationServer.Integration.GCPPubSub)
+		case "kafka":
+			i, err = kafka.New(marshalType, conf.ApplicationServer.Integration.Kafka)
 		case "postgresql":
 			i, err = postgresql.New(conf.ApplicationServer.Integration.PostgreSQL)
 		case "amqp":

--- a/internal/integration/kafka/kafka.go
+++ b/internal/integration/kafka/kafka.go
@@ -1,0 +1,124 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/segmentio/kafka-go"
+
+	pb "github.com/brocaar/chirpstack-api/go/v3/as/integration"
+	"github.com/brocaar/chirpstack-application-server/internal/config"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/marshaler"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/models"
+	"github.com/brocaar/chirpstack-application-server/internal/logging"
+	"github.com/brocaar/lorawan"
+)
+
+// Integration implements an Kafka integration.
+type Integration struct {
+	marshaler marshaler.Type
+	writer    *kafka.Writer
+	wg        sync.WaitGroup
+	config    config.IntegrationKafkaConfig
+}
+
+// New creates a new Kafka integration.
+func New(m marshaler.Type, conf config.IntegrationKafkaConfig) (*Integration, error) {
+	w := kafka.NewWriter(kafka.WriterConfig{
+		Brokers:  conf.Brokers,
+		Topic:    conf.Topic,
+		Balancer: &kafka.LeastBytes{},
+	})
+
+	i := Integration{
+		marshaler: m,
+		writer:    w,
+		config:    conf,
+	}
+	return &i, nil
+}
+
+// HandleUplinkEvent sends an UplinkEvent.
+func (i *Integration) HandleUplinkEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.UplinkEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "up", &pl)
+}
+
+// HandleJoinEvent sends a JoinEvent.
+func (i *Integration) HandleJoinEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.JoinEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "join", &pl)
+}
+
+// HandleAckEvent sends an AckEvent.
+func (i *Integration) HandleAckEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.AckEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "ack", &pl)
+}
+
+// HandleErrorEvent sends an ErrorEvent.
+func (i *Integration) HandleErrorEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.ErrorEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "error", &pl)
+}
+
+// HandleStatusEvent sends a StatusEvent.
+func (i *Integration) HandleStatusEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.StatusEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "status", &pl)
+}
+
+// HandleLocationEvent sends a LocationEvent.
+func (i *Integration) HandleLocationEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.LocationEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "location", &pl)
+}
+
+// HandleTxAckEvent sends a TxAckEvent.
+func (i *Integration) HandleTxAckEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.TxAckEvent) error {
+	return i.publish(ctx, pl.ApplicationId, pl.DevEui, "txack", &pl)
+}
+
+func (i *Integration) publish(ctx context.Context, applicationID uint64, devEUIB []byte, event string, msg proto.Message) error {
+	if i.writer == nil {
+		return fmt.Errorf("integration closed")
+	}
+
+	var devEUI lorawan.EUI64
+	copy(devEUI[:], devEUIB)
+
+	b, err := marshaler.Marshal(i.marshaler, msg)
+	if err != nil {
+		return err
+	}
+	key := fmt.Sprintf("application.%d.device.%s", applicationID, devEUI.String())
+	kmsg := kafka.Message{
+		Key:   []byte(key),
+		Value: b,
+	}
+
+	log.WithFields(log.Fields{
+		"dev_eui": devEUI.String(),
+		"event":   event,
+		"ctx_id":  ctx.Value(logging.ContextIDKey),
+	}).Info("integration/kafka: publishing message")
+
+	if err := i.writer.WriteMessages(ctx, kmsg); err != nil {
+		return errors.Wrap(err, "writing message to kafka")
+	}
+	return nil
+}
+
+// DataDownChan return nil.
+func (i *Integration) DataDownChan() chan models.DataDownPayload {
+	return nil
+}
+
+// Close shuts down the integration, closing the Kafka writer.
+func (i *Integration) Close() error {
+	if i.writer == nil {
+		return fmt.Errorf("integration already closed")
+	}
+	err := i.writer.Close()
+	i.writer = nil
+	return err
+}

--- a/internal/integration/kafka/kafka_test.go
+++ b/internal/integration/kafka/kafka_test.go
@@ -77,7 +77,7 @@ func (ts *IntegrationTestSuite) checkMessage(err error, tx, rx proto.Message) {
 	msg, err := ts.conn.ReadMessage(1 << 10)
 	assert.NoError(err)
 
-	assert.Equal("application.10.device.0102030405060708", string(msg.Key))
+	assert.Equal("application.10.device.0102030405060708.event.up", string(msg.Key))
 
 	assert.NoError(proto.Unmarshal(msg.Value, rx))
 	assert.True(proto.Equal(tx, rx))

--- a/internal/integration/kafka/kafka_test.go
+++ b/internal/integration/kafka/kafka_test.go
@@ -1,0 +1,88 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	pb "github.com/brocaar/chirpstack-api/go/v3/as/integration"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/marshaler"
+	"github.com/brocaar/chirpstack-application-server/internal/test"
+	"github.com/brocaar/lorawan"
+
+	"github.com/segmentio/kafka-go"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+	integration *Integration
+
+	applicationID uint64
+	devEUI        lorawan.EUI64
+
+	conn *kafka.Conn
+}
+
+func (ts *IntegrationTestSuite) SetupSuite() {
+	assert := require.New(ts.T())
+	conf := test.GetConfig()
+
+	ts.applicationID = 10
+	ts.devEUI = lorawan.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	kafkaConf := conf.ApplicationServer.Integration.Kafka
+
+	// Note: We instantiate a reader before we instantiate the integration. An
+	// integration immediately creates a writer. If kafka was just started for the
+	// first time for our tests, that first writer connection and kafka are in a state
+	// where the first message write fails: "Leader Not Available: the cluster is in
+	// the middle of a leadership election and there is currently no leader for this
+	// partition and hence it is unavailable for writes". Creating a reader first seems
+	// to prevent that.
+
+	var err error
+	ts.conn, err = kafka.DialLeader(context.Background(), "tcp", kafkaConf.Brokers[0], kafkaConf.Topic, 0)
+	assert.NoError(err)
+
+	_, err = ts.conn.Seek(0, kafka.SeekEnd)
+	assert.NoError(err)
+
+	ts.integration, err = New(marshaler.Protobuf, kafkaConf)
+	assert.NoError(err)
+}
+
+func (ts *IntegrationTestSuite) TearDownSuite() {
+	assert := require.New(ts.T())
+	assert.NoError(ts.conn.Close())
+}
+
+func (ts *IntegrationTestSuite) TestUplink() {
+	tx := pb.UplinkEvent{
+		ApplicationId: ts.applicationID,
+		DevEui:        ts.devEUI[:],
+	}
+	var rx pb.UplinkEvent
+	err := ts.integration.HandleUplinkEvent(context.Background(), nil, nil, tx)
+	ts.checkMessage(err, &tx, &rx)
+}
+
+func (ts *IntegrationTestSuite) checkMessage(err error, tx, rx proto.Message) {
+	assert := require.New(ts.T())
+
+	assert.NoError(err)
+
+	msg, err := ts.conn.ReadMessage(1 << 10)
+	assert.NoError(err)
+
+	assert.Equal("application.10.device.0102030405060708", string(msg.Key))
+
+	assert.NoError(proto.Unmarshal(msg.Value, rx))
+	assert.True(proto.Equal(tx, rx))
+}
+
+func TestIntegration(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -27,6 +27,7 @@ func GetConfig() config.Config {
 	c.ApplicationServer.Integration.MQTT.Server = "tcp://localhost:1883"
 	c.ApplicationServer.ID = "6d5db27e-4ce2-4b2b-b5d7-91f069397978"
 	c.ApplicationServer.Integration.AMQP.EventRoutingKeyTemplate = "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}"
+	c.ApplicationServer.Integration.Kafka.Topic = "chirpstack_as"
 
 	if v := os.Getenv("TEST_POSTGRES_DSN"); v != "" {
 		c.PostgreSQL.DSN = v
@@ -50,6 +51,10 @@ func GetConfig() config.Config {
 
 	if v := os.Getenv("TEST_RABBITMQ_URL"); v != "" {
 		c.ApplicationServer.Integration.AMQP.URL = v
+	}
+
+	if v := os.Getenv("TEST_KAFKA_BROKER"); v != "" {
+		c.ApplicationServer.Integration.Kafka.Brokers = []string{v}
 	}
 
 	return c

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -28,6 +28,7 @@ func GetConfig() config.Config {
 	c.ApplicationServer.ID = "6d5db27e-4ce2-4b2b-b5d7-91f069397978"
 	c.ApplicationServer.Integration.AMQP.EventRoutingKeyTemplate = "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}"
 	c.ApplicationServer.Integration.Kafka.Topic = "chirpstack_as"
+	c.ApplicationServer.Integration.Kafka.EventKeyTemplate = "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}"
 
 	if v := os.Getenv("TEST_POSTGRES_DSN"); v != "" {
 		c.PostgreSQL.DSN = v


### PR DESCRIPTION
using github.com/segmentio/kafka-go as kafka library.

including tests using bitnami/{kafka,zookeeper}.

similar to other integrations.

kafka broker(s) and topic can be configured.
message keys include application ID and dev EUI.