### PR TITLE
add missing error check in aws sns integration

### DIFF
--- a/internal/integration/awssns/aws_sns.go
+++ b/internal/integration/awssns/aws_sns.go
@@ -125,6 +125,9 @@ func (i *Integration) publish(ctx context.Context, event string, applicationID u
 		},
 		TopicArn: aws.String(i.topicARN),
 	})
+	if err != nil {
+		return errors.Wrap(err, "sns publish")
+	}
 
 	log.WithFields(log.Fields{
 		"dev_eui": devEUI,


### PR DESCRIPTION
Err was assigned but never checked, so probably an oversight.