### PR TITLE
Fixed Makefile to speed up.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build clean test ui-requirements serve internal/statics internal/migrations 
-PKGS := $(shell go list ./... | grep -v /vendor |grep -v chirpstack-application-server/api | grep -v /migrations | grep -v /static | grep -v /ui)
+PKGS := $(shell go list ./cmd/... ./internal/... | grep -v /vendor |grep -v chirpstack-application-server/api)
 VERSION := $(shell git describe --always |sed -e "s/^v//")
 API_VERSION := $(shell go list -m -f '{{ .Version }}' github.com/brocaar/chirpstack-api/go/v3 | awk '{n=split($$0, a, "-"); print a[n]}')
 


### PR DESCRIPTION
Hi,

I was suffering from the very slow build of chirpstack-application-server.
The reason was `go list ./...` at the second line of Makefile.
After `make ui-requirements`, the build time got slow seriously.
Especially, under the Windows and macOS that use VM based Docker environment, it got much slower than Linux.
So I fixed it not to list `ui` and its sub directories.

Please, review it.

Thank you.
Jongsoo Jeong