### PR TITLE
Update configfile.go

### DIFF
--- a/cmd/chirpstack-application-server/cmd/configfile.go
+++ b/cmd/chirpstack-application-server/cmd/configfile.go
@@ -362,7 +362,7 @@ id="{{ .ApplicationServer.ID }}"
   # TLS.
   #
   # Set this to true when the Kafka client must connect using TLS to the Broker.
-  tls={{ .ApplicationServer.Integration.TLS }}
+  tls={{ .ApplicationServer.Integration.Kafka.TLS }}
 
   # Topic for events.
   topic="{{ .ApplicationServer.Integration.Kafka.Topic }}"


### PR DESCRIPTION
Resolved config file generating an error 
Error: can't evaluate field TLS in type struct

`can't evaluate field TLS in type struct`

![image](https://user-images.githubusercontent.com/43664335/89294870-b5f1cc00-d67d-11ea-8e08-219caad15f4d.png)

@brocaar Please review my change