### PR TITLE
call missing npm install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ proto:
 
 ui/build:
 	@echo "Building ui"
+	@cd ui && npm install
 	@cd ui && npm run build
 	@mv ui/build/* static
 


### PR DESCRIPTION
If that isn't present running "make" after cloning doesn't work.