### PR TITLE
Fix autocompleteselect placeholder

### DIFF
--- a/ui/src/components/AutocompleteSelect.js
+++ b/ui/src/components/AutocompleteSelect.js
@@ -76,7 +76,7 @@ class AutocompleteSelect extends Component {
         onChange={this.onChange}
         onInputChange={this.onInputChange}
         className={this.props.className}
-        renderInput={(params) => <TextField required={!!this.props.required} {...params} /> }
+        renderInput={(params) => <TextField required={!!this.props.required} placeholder={this.props.label} {...params} /> }
         disableClearable={!this.props.clearable}
       />
     );


### PR DESCRIPTION
- This is a bugfix for issue [#524](https://github.com/brocaar/chirpstack-application-server/issues/524)

Select controls were not displaying their placeholder value. To fix this a placeholder property has been added to `<TextField>` in the AutoCompleteSelect