### PR TITLE
Don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ FROM alpine:3.11.2 AS production
 
 RUN apk --no-cache add ca-certificates
 COPY --from=development /chirpstack-application-server/build/chirpstack-application-server /usr/bin/chirpstack-application-server
+USER nobody:nogroup
 ENTRYPOINT ["/usr/bin/chirpstack-application-server"]


### PR DESCRIPTION
It's a good practice to avoid running docker containers with root access

I currently have the app server deployed with a wrapping docker container performing the same

```dockerfile
FROM chirpstack/chirpstack-application-server:3.11.1
USER nobody:nogroup
ENTRYPOINT ["/usr/bin/chirpstack-application-server"]

```