### PR TITLE
The lock key for downstream messsages base on message content

### DIFF
--- a/internal/integration/mqtt/mqtt.go
+++ b/internal/integration/mqtt/mqtt.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+  "crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -407,7 +408,7 @@ func (i *Integration) txPayloadHandler(mqttc mqtt.Client, msg mqtt.Message) {
 	// Since with MQTT all subscribers will receive the downlink messages sent
 	// by the application, the first instance receiving the message must lock it,
 	// so that other instances can ignore the message.
-	key := fmt.Sprintf("lora:as:downlink:lock:%d:%s", pl.ApplicationID, pl.DevEUI)
+  key := fmt.Sprintf("lora:as:downlink:lock:%d:%s:%x", pl.ApplicationID, pl.DevEUI, sha256.Sum256(msg.Payload()))
 	set, err := storage.RedisClient().SetNX(key, "lock", downlinkLockTTL).Result()
 	if err != nil {
 		log.WithError(err).Error("integration/mqtt: acquire lock error")

--- a/internal/integration/mqtt/mqtt.go
+++ b/internal/integration/mqtt/mqtt.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-  "crypto/sha256"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -408,7 +408,7 @@ func (i *Integration) txPayloadHandler(mqttc mqtt.Client, msg mqtt.Message) {
 	// Since with MQTT all subscribers will receive the downlink messages sent
 	// by the application, the first instance receiving the message must lock it,
 	// so that other instances can ignore the message.
-  key := fmt.Sprintf("lora:as:downlink:lock:%d:%s:%x", pl.ApplicationID, pl.DevEUI, sha256.Sum256(msg.Payload()))
+	key := fmt.Sprintf("lora:as:downlink:lock:%d:%s:%x", pl.ApplicationID, pl.DevEUI, sha256.Sum256(msg.Payload()))
 	set, err := storage.RedisClient().SetNX(key, "lock", downlinkLockTTL).Result()
 	if err != nil {
 		log.WithError(err).Error("integration/mqtt: acquire lock error")


### PR DESCRIPTION
Fixes [#575](https://github.com/brocaar/chirpstack-application-server/issues/575) 

NOTE: the tests fail on docker-compose because of the issue with the latest mosquito image (see [issue](https://github.com/eclipse/mosquitto/issues/2040)) but pass fine if you specify mosquito version below 2.0.0 in docker-compose. I've been testing with version 1.6.12