### PR TITLE
Store uplink is of type confirmed/unconfirmed + dev-addr in postgres integration.

### DIFF
--- a/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.down.sql
+++ b/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE IF EXISTS device_up
-    DROP COLUMN IF EXISTS dev_addr,
-    DROP COLUMN IF EXISTS confirmed_uplink;
+ALTER TABLE device_up
+    DROP COLUMN dev_addr,
+    DROP COLUMN confirmed_uplink;

--- a/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.down.sql
+++ b/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE IF EXISTS device_up
+    DROP COLUMN IF EXISTS dev_addr,
+    DROP COLUMN IF EXISTS confirmed_uplink;

--- a/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.up.sql
+++ b/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE IF EXISTS device_up
-    ADD COLUMN IF NOT EXISTS dev_addr bytea,
-    ADD COLUMN IF NOT EXISTS confirmed_uplink boolean not null default false;
+ALTER TABLE device_up
+    ADD COLUMN dev_addr bytea,
+    ADD COLUMN confirmed_uplink boolean not null default false;

--- a/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.up.sql
+++ b/internal/integration/postgresql/migrations/0002_devaddr_uplink_type.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE IF EXISTS device_up
+    ADD COLUMN IF NOT EXISTS dev_addr bytea,
+    ADD COLUMN IF NOT EXISTS confirmed_uplink boolean not null default false;

--- a/internal/integration/postgresql/postgresql.go
+++ b/internal/integration/postgresql/postgresql.go
@@ -180,7 +180,9 @@ func (i *Integration) HandleUplinkEvent(ctx context.Context, _ models.Integratio
 	}
 
 	var devEUI lorawan.EUI64
+	var devAddr lorawan.DevAddr
 	copy(devEUI[:], pl.DevEui)
+	copy(devAddr[:], pl.DevAddr)
 
 	_, err = i.db.Exec(`
 		insert into device_up (
@@ -198,8 +200,10 @@ func (i *Integration) HandleUplinkEvent(ctx context.Context, _ models.Integratio
 			data,
 			rx_info,
 			object,
-			tags
-		) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+			tags,
+			confirmed_uplink,
+			dev_addr
+		) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
 		id,
 		rxTime,
 		devEUI,
@@ -215,6 +219,8 @@ func (i *Integration) HandleUplinkEvent(ctx context.Context, _ models.Integratio
 		rxInfoJSON,
 		objectJSON,
 		tagsToHstore(pl.Tags),
+		pl.ConfirmedUplink,
+		devAddr[:],
 	)
 	if err != nil {
 		return errors.Wrap(err, "insert error")

--- a/internal/integration/postgresql/postgresql_test.go
+++ b/internal/integration/postgresql/postgresql_test.go
@@ -44,6 +44,8 @@ type deviceUp struct {
 	RXInfo          json.RawMessage `db:"rx_info"`
 	Object          json.RawMessage `db:"object"`
 	Tags            hstore.Hstore   `db:"tags"`
+	DevAddr         lorawan.DevAddr `db:"dev_addr"`
+	ConfirmedUplink bool            `db:"confirmed_uplink"`
 }
 
 type deviceStatus struct {
@@ -218,6 +220,8 @@ func (ts *PostgreSQLTestSuite) TestHandleUplinkEvent() {
 		Tags: map[string]string{
 			"foo": "bar",
 		},
+		ConfirmedUplink: true,
+		DevAddr:         []byte{1, 2, 3, 4},
 	}
 
 	assert.NoError(ts.integration.HandleUplinkEvent(context.Background(), nil, nil, pl))
@@ -252,6 +256,8 @@ func (ts *PostgreSQLTestSuite) TestHandleUplinkEvent() {
 				"foo": sql.NullString{String: "bar", Valid: true},
 			},
 		},
+		ConfirmedUplink: true,
+		DevAddr:         lorawan.DevAddr{1, 2, 3, 4},
 	}, up)
 }
 
@@ -286,6 +292,8 @@ func (ts *PostgreSQLTestSuite) TestHandleUplinkEventNoObject() {
 		Tags: map[string]string{
 			"foo": "bar",
 		},
+		ConfirmedUplink: true,
+		DevAddr:         []byte{1, 2, 3, 4},
 	}
 
 	assert.NoError(ts.integration.HandleUplinkEvent(context.Background(), nil, nil, pl))
@@ -319,6 +327,8 @@ func (ts *PostgreSQLTestSuite) TestHandleUplinkEventNoObject() {
 				"foo": sql.NullString{String: "bar", Valid: true},
 			},
 		},
+		ConfirmedUplink: true,
+		DevAddr:         lorawan.DevAddr{1, 2, 3, 4},
 	}, up)
 }
 
@@ -352,6 +362,8 @@ func (ts *PostgreSQLTestSuite) TestUplinkEventNoData() {
 		Tags: map[string]string{
 			"foo": "bar",
 		},
+		ConfirmedUplink: false,
+		DevAddr:         []byte{1, 2, 3, 4},
 	}
 
 	assert.NoError(ts.integration.HandleUplinkEvent(context.Background(), nil, nil, pl))
@@ -385,6 +397,8 @@ func (ts *PostgreSQLTestSuite) TestUplinkEventNoData() {
 				"foo": sql.NullString{String: "bar", Valid: true},
 			},
 		},
+		ConfirmedUplink: false,
+		DevAddr:         lorawan.DevAddr{1, 2, 3, 4},
 	}, up)
 }
 


### PR DESCRIPTION
Fixes #560 

@brocaar Please review my change.

Is it required to Store `RXINFO` in `JoinEvent`? if required then I will commit to this PR.