### PR TITLE
InfluxDB V2 Integration

### DIFF
--- a/internal/integration/influxdbv2/influxdb.go
+++ b/internal/integration/influxdbv2/influxdb.go
@@ -1,0 +1,516 @@
+// Package influxdb implements a InfluxDB integration.
+package influxdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mmcloughlin/geohash"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	pb "github.com/brocaar/chirpstack-api/go/v3/as/integration"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/models"
+	"github.com/brocaar/chirpstack-application-server/internal/logging"
+	"github.com/brocaar/lorawan"
+)
+
+var precisionValidator = regexp.MustCompile(`^(ns|u|ms|s|m|h)$`)
+
+// Config contains the configuration for the InfluxDB integration.
+type Config struct {
+	Endpoint            string `json:"endpoint"`
+	DB                  string `json:"db"`
+	Username            string `json:"username"`
+	Password            string `json:"password"`
+	RetentionPolicyName string `json:"retentionPolicyName"`
+	Precision           string `json:"precision"`
+}
+
+// Validate validates the HandlerConfig data.
+func (c Config) Validate() error {
+	if !precisionValidator.MatchString(c.Precision) {
+		return ErrInvalidPrecision
+	}
+	return nil
+}
+
+type measurement struct {
+	Name   string
+	Tags   map[string]string
+	Values map[string]interface{}
+}
+
+func (m measurement) String() string {
+	var tags []string
+	var values []string
+
+	for k, v := range m.Tags {
+		tags = append(tags, fmt.Sprintf("%s=%v", escapeInfluxTag(k), formatInfluxValue(escapeInfluxTag(v), false)))
+	}
+
+	for k, v := range m.Values {
+		values = append(values, fmt.Sprintf("%s=%v", k, formatInfluxValue(v, true)))
+	}
+
+	// as maps are unsorted the order of tags and values is random.
+	// this is not an issue for influxdb, but makes testing more complex.
+	sort.Strings(tags)
+	sort.Strings(values)
+
+	return fmt.Sprintf("%s,%s %s", m.Name, strings.Join(tags, ","), strings.Join(values, ","))
+}
+
+func formatInfluxValue(v interface{}, quote bool) string {
+	switch v := v.(type) {
+	case float32, float64:
+		return fmt.Sprintf("%f", v)
+	case int, uint, uint8, int8, uint16, int16, uint32, int32, uint64, int64:
+		return fmt.Sprintf("%di", v)
+	case string:
+		if quote {
+			return strconv.Quote(v)
+		}
+		return v
+	case bool:
+		return fmt.Sprintf("%t", v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// see https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#special-characters
+func escapeInfluxTag(str string) string {
+	replace := map[string]string{
+		",": `\,`,
+		"=": `\=`,
+		" ": `\ `,
+	}
+
+	for k, v := range replace {
+		str = strings.ReplaceAll(str, k, v)
+	}
+
+	return str
+}
+
+// Integration implements an InfluxDB integration.
+type Integration struct {
+	config Config
+}
+
+// New creates a new InfluxDB integration.
+func New(conf Config) (*Integration, error) {
+	return &Integration{
+		config: conf,
+	}, nil
+}
+
+func (i *Integration) send(measurements []measurement) error {
+	var measStr []string
+	for _, m := range measurements {
+		measStr = append(measStr, m.String())
+	}
+	sort.Strings(measStr)
+
+	b := []byte(strings.Join(measStr, "\n"))
+
+	args := url.Values{}
+	args.Set("db", i.config.DB)
+	args.Set("precision", i.config.Precision)
+	args.Set("rp", i.config.RetentionPolicyName)
+
+	req, err := http.NewRequest("POST", i.config.Endpoint+"?"+args.Encode(), bytes.NewReader(b))
+	if err != nil {
+		return errors.Wrap(err, "new request error")
+	}
+
+	req.Header.Set("Content-Type", "text/plain")
+
+	if i.config.Username != "" || i.config.Password != "" {
+		req.SetBasicAuth(i.config.Username, i.config.Password)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "http request error")
+	}
+	defer resp.Body.Close()
+
+	// check that response is in 200 range
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("expected 2xx response, got: %d (%s)", resp.StatusCode, string(b))
+	}
+
+	return nil
+}
+
+// Close closes the handler.
+func (i *Integration) Close() error {
+	return nil
+}
+
+// HandleUplinkEvent writes the uplink into InfluxDB.
+func (i *Integration) HandleUplinkEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.UplinkEvent) error {
+	if pl.ObjectJson == "" {
+		return nil
+	}
+
+	var obj interface{}
+	if err := json.Unmarshal([]byte(pl.ObjectJson), &obj); err != nil {
+		return errors.Wrap(err, "unmarshal json error")
+	}
+
+	var devEUI lorawan.EUI64
+	copy(devEUI[:], pl.DevEui)
+
+	tags := map[string]string{
+		"application_name": pl.ApplicationName,
+		"device_name":      pl.DeviceName,
+		"dev_eui":          devEUI.String(),
+		"dr":               strconv.FormatInt(int64(pl.Dr), 10),
+		"frequency":        strconv.FormatInt(int64(pl.GetTxInfo().GetFrequency()), 10),
+	}
+	for k, v := range pl.Tags {
+		tags[k] = v
+	}
+
+	var measurements []measurement
+
+	// add data-rate measurement
+	measurements = append(measurements, measurement{
+		Name: "device_uplink",
+		Tags: tags,
+		Values: map[string]interface{}{
+			"value": 1,
+			"f_cnt": pl.FCnt,
+		},
+	})
+
+	if len(pl.RxInfo) != 0 {
+		var rssi int32
+		for i, rxInfo := range pl.RxInfo {
+			if i == 0 || rxInfo.Rssi > rssi {
+				rssi = rxInfo.Rssi
+			}
+		}
+
+		var snr float64
+		for i, rxInfo := range pl.RxInfo {
+			if i == 0 || rxInfo.LoraSnr > snr {
+				snr = rxInfo.LoraSnr
+			}
+		}
+
+		measurements[0].Values["rssi"] = rssi
+		measurements[0].Values["snr"] = snr
+	}
+
+	// parse object to measurements
+	measurements = append(measurements, objectToMeasurements(pl, "device_frmpayload_data", obj)...)
+
+	if len(measurements) == 0 {
+		return nil
+	}
+
+	if err := i.send(measurements); err != nil {
+		return errors.Wrap(err, "sending measurements error")
+	}
+
+	log.WithFields(log.Fields{
+		"dev_eui": devEUI,
+		"ctx_id":  ctx.Value(logging.ContextIDKey),
+	}).Info("integration/influxdb: uplink measurements written")
+
+	return nil
+}
+
+// HandleStatusEvent writes the device-status into InfluxDB.
+func (i *Integration) HandleStatusEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.StatusEvent) error {
+	var devEUI lorawan.EUI64
+	copy(devEUI[:], pl.DevEui)
+
+	tags := map[string]string{
+		"application_name": pl.ApplicationName,
+		"device_name":      pl.DeviceName,
+		"dev_eui":          devEUI.String(),
+	}
+	for k, v := range pl.Tags {
+		tags[k] = v
+	}
+
+	var measurements []measurement
+
+	if !pl.ExternalPowerSource && !pl.BatteryLevelUnavailable {
+		measurements = append(measurements, measurement{
+			Name: "device_status_battery_level",
+			Tags: tags,
+			Values: map[string]interface{}{
+				"value": pl.BatteryLevel,
+			},
+		})
+	}
+
+	measurements = append(measurements, measurement{
+		Name: "device_status_margin",
+		Tags: tags,
+		Values: map[string]interface{}{
+			"value": pl.Margin,
+		},
+	})
+
+	if err := i.send(measurements); err != nil {
+		return errors.Wrap(err, "sending measurements error")
+	}
+
+	log.WithFields(log.Fields{
+		"dev_eui": devEUI,
+		"ctx_id":  ctx.Value(logging.ContextIDKey),
+	}).Info("integration/influxdb: status measurements written")
+
+	return nil
+}
+
+// HandleJoinEvent is not implemented.
+func (i *Integration) HandleJoinEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.JoinEvent) error {
+	return nil
+}
+
+// HandleAckEvent is not implemented.
+func (i *Integration) HandleAckEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.AckEvent) error {
+	return nil
+}
+
+// HandleErrorEvent is not implemented.
+func (i *Integration) HandleErrorEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.ErrorEvent) error {
+	return nil
+}
+
+// HandleLocationEvent is not implemented.
+func (i *Integration) HandleLocationEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.LocationEvent) error {
+	return nil
+}
+
+// HandleTxAckEvent is not implemented.
+func (i *Integration) HandleTxAckEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.TxAckEvent) error {
+	return nil
+}
+
+// HandleIntegrationEvent is not implemented.
+func (i *Integration) HandleIntegrationEvent(ctx context.Context, _ models.Integration, vars map[string]string, pl pb.IntegrationEvent) error {
+	return nil
+}
+
+// DataDownChan return nil.
+func (i *Integration) DataDownChan() chan models.DataDownPayload {
+	return nil
+}
+
+func objectToMeasurements(pl pb.UplinkEvent, prefix string, obj interface{}) []measurement {
+	var out []measurement
+
+	if obj == nil {
+		return out
+	}
+
+	var devEUI lorawan.EUI64
+	copy(devEUI[:], pl.DevEui)
+
+	switch o := obj.(type) {
+	case int, uint, float32, float64, uint8, int8, uint16, int16, uint32, int32, uint64, int64, string, bool:
+		tags := map[string]string{
+			"application_name": pl.ApplicationName,
+			"device_name":      pl.DeviceName,
+			"dev_eui":          devEUI.String(),
+			"f_port":           strconv.FormatInt(int64(pl.FPort), 10),
+		}
+		for k, v := range pl.Tags {
+			tags[k] = v
+		}
+
+		out = append(out, measurement{
+			Name: prefix,
+			Tags: tags,
+			Values: map[string]interface{}{
+				"value": o,
+			},
+		})
+
+	default:
+		switch reflect.TypeOf(o).Kind() {
+		case reflect.Map:
+			v := reflect.ValueOf(o)
+			keys := v.MapKeys()
+
+			out = append(out, mapToLocation(pl, prefix, v)...)
+
+			for _, k := range keys {
+				keyName := fmt.Sprintf("%v", k.Interface())
+				if _, ignore := map[string]struct{}{
+					"latitude":  struct{}{},
+					"longitude": struct{}{},
+				}[keyName]; ignore {
+					continue
+				}
+
+				out = append(out, objectToMeasurements(pl, prefix+"_"+keyName, v.MapIndex(k).Interface())...)
+			}
+
+		case reflect.Struct:
+			v := reflect.ValueOf(o)
+			l := v.NumField()
+
+			out = append(out, structToLocation(pl, prefix, v)...)
+
+			for i := 0; i < l; i++ {
+				if !v.Field(i).CanInterface() {
+					continue
+				}
+
+				fieldName := v.Type().Field(i).Tag.Get("influxdb")
+				if fieldName == "" {
+					fieldName = strings.ToLower(v.Type().Field(i).Name)
+				}
+
+				if _, ignore := map[string]struct{}{
+					"latitude":  struct{}{},
+					"longitude": struct{}{},
+				}[fieldName]; ignore {
+					continue
+				}
+
+				out = append(out, objectToMeasurements(pl, prefix+"_"+fieldName, v.Field(i).Interface())...)
+			}
+
+		case reflect.Ptr:
+			v := reflect.Indirect(reflect.ValueOf(o))
+			out = append(out, objectToMeasurements(pl, prefix, v.Interface())...)
+
+		default:
+			log.WithField("type_name", fmt.Sprintf("%T", o)).Warning("influxdb integration: unhandled type!")
+		}
+
+	}
+
+	return out
+}
+
+func mapToLocation(pl pb.UplinkEvent, prefix string, obj reflect.Value) []measurement {
+	var latFloat, longFloat float64
+
+	keys := obj.MapKeys()
+	for _, k := range keys {
+		if strings.ToLower(k.String()) == "latitude" {
+			switch v := obj.MapIndex(k).Interface().(type) {
+			case float32:
+				latFloat = float64(v)
+			case float64:
+				latFloat = v
+			}
+		}
+
+		if strings.ToLower(k.String()) == "longitude" {
+			switch v := obj.MapIndex(k).Interface().(type) {
+			case float32:
+				longFloat = float64(v)
+			case float64:
+				longFloat = v
+			}
+		}
+	}
+
+	if latFloat == 0 && longFloat == 0 {
+		return nil
+	}
+
+	var devEUI lorawan.EUI64
+	copy(devEUI[:], pl.DevEui)
+
+	tags := map[string]string{
+		"application_name": pl.ApplicationName,
+		"device_name":      pl.DeviceName,
+		"dev_eui":          devEUI.String(),
+		"f_port":           strconv.FormatInt(int64(pl.FPort), 10),
+	}
+	for k, v := range pl.Tags {
+		tags[k] = v
+	}
+
+	return []measurement{
+		{
+			Name: prefix + "_location",
+			Tags: tags,
+			Values: map[string]interface{}{
+				"latitude":  latFloat,
+				"longitude": longFloat,
+				"geohash":   geohash.Encode(latFloat, longFloat),
+			},
+		},
+	}
+}
+
+func structToLocation(pl pb.UplinkEvent, prefix string, obj reflect.Value) []measurement {
+	var latFloat, longFloat float64
+
+	l := obj.NumField()
+	for i := 0; i < l; i++ {
+		fieldName := strings.ToLower(obj.Type().Field(i).Name)
+		if fieldName == "latitude" {
+			switch v := obj.Field(i).Interface().(type) {
+			case float32:
+				latFloat = float64(v)
+			case float64:
+				latFloat = v
+			}
+		}
+
+		if fieldName == "longitude" {
+			switch v := obj.Field(i).Interface().(type) {
+			case float32:
+				longFloat = float64(v)
+			case float64:
+				longFloat = v
+			}
+		}
+	}
+
+	if latFloat == 0 && longFloat == 0 {
+		return nil
+	}
+
+	var devEUI lorawan.EUI64
+	copy(devEUI[:], pl.DevEui)
+
+	tags := map[string]string{
+		"application_name": pl.ApplicationName,
+		"device_name":      pl.DeviceName,
+		"dev_eui":          devEUI.String(),
+		"f_port":           strconv.FormatInt(int64(pl.FPort), 10),
+	}
+	for k, v := range pl.Tags {
+		tags[k] = v
+	}
+
+	return []measurement{
+		{
+			Name: prefix + "_location",
+			Tags: tags,
+			Values: map[string]interface{}{
+				"latitude":  latFloat,
+				"longitude": longFloat,
+				"geohash":   geohash.Encode(latFloat, longFloat),
+			},
+		},
+	}
+}

--- a/internal/integration/influxdbv2/influxdb_test.go
+++ b/internal/integration/influxdbv2/influxdb_test.go
@@ -1,0 +1,339 @@
+package influxdb
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	pb "github.com/brocaar/chirpstack-api/go/v3/as/integration"
+	"github.com/brocaar/chirpstack-api/go/v3/gw"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/models"
+)
+
+func init() {
+	log.SetLevel(log.ErrorLevel)
+}
+
+type testHTTPHandler struct {
+	requests chan *http.Request
+}
+
+func (h *testHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	b, _ := ioutil.ReadAll(r.Body)
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
+	h.requests <- r
+	w.WriteHeader(http.StatusOK)
+}
+
+type HandlerTestSuite struct {
+	suite.Suite
+
+	Handler  models.IntegrationHandler
+	Requests chan *http.Request
+	Server   *httptest.Server
+}
+
+func (ts *HandlerTestSuite) SetupSuite() {
+	assert := require.New(ts.T())
+	ts.Requests = make(chan *http.Request, 100)
+
+	httpHandler := testHTTPHandler{
+		requests: ts.Requests,
+	}
+	ts.Server = httptest.NewServer(&httpHandler)
+
+	conf := Config{
+		Endpoint:            ts.Server.URL + "/write",
+		DB:                  "chirpstack",
+		Username:            "user",
+		Password:            "password",
+		RetentionPolicyName: "DEFAULT",
+		Precision:           "s",
+	}
+	var err error
+	ts.Handler, err = New(conf)
+	assert.NoError(err)
+}
+
+func (ts *HandlerTestSuite) TearDownSuite() {
+	ts.Server.Close()
+}
+
+func (ts *HandlerTestSuite) TestStatus() {
+	tests := []struct {
+		Name         string
+		Payload      pb.StatusEvent
+		ExpectedBody string
+	}{
+		{
+			Name: "margin and battery status",
+			Payload: pb.StatusEvent{
+				ApplicationName: "test-app",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				DeviceName:      "test-device",
+				BatteryLevel:    48.43,
+				Margin:          10,
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			ExpectedBody: `device_status_battery_level,application_name=test-app,dev_eui=0102030405060708,device_name=test-device,foo=bar value=48.430000
+device_status_margin,application_name=test-app,dev_eui=0102030405060708,device_name=test-device,foo=bar value=10i`,
+		},
+	}
+
+	for _, tst := range tests {
+		ts.T().Run(tst.Name, func(t *testing.T) {
+			assert := require.New(t)
+			assert.NoError(ts.Handler.HandleStatusEvent(context.Background(), nil, nil, tst.Payload))
+			req := <-ts.Requests
+			assert.Equal("/write", req.URL.Path)
+			assert.Equal(url.Values{
+				"db":        []string{"chirpstack"},
+				"precision": []string{"s"},
+				"rp":        []string{"DEFAULT"},
+			}, req.URL.Query())
+
+			b, err := ioutil.ReadAll(req.Body)
+			assert.NoError(err)
+			assert.Equal(tst.ExpectedBody, string(b))
+
+			user, pw, ok := req.BasicAuth()
+			assert.Equal("user", user)
+			assert.Equal("password", pw)
+			assert.True(ok)
+
+			assert.Equal("text/plain", req.Header.Get("Content-Type"))
+		})
+	}
+}
+
+func (ts *HandlerTestSuite) TestUplink() {
+	tests := []struct {
+		Name         string
+		Payload      pb.UplinkEvent
+		ExpectedBody string
+	}{
+		{
+			Name: "One level depth",
+			Payload: pb.UplinkEvent{
+				ApplicationName: "test-app",
+				DeviceName:      "test-dev",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				FCnt:            10,
+				FPort:           20,
+				Dr:              2,
+				TxInfo: &gw.UplinkTXInfo{
+					Frequency: 868100000,
+				},
+				ObjectJson: `{
+					"temperature": 25.4,
+					"humidity":    20,
+					"active":      true,
+					"status":      "on"
+				}`,
+				Tags: map[string]string{
+					"fo o": "ba,r",
+				},
+			},
+			ExpectedBody: `device_frmpayload_data_active,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\ o=ba\,r value=true
+device_frmpayload_data_humidity,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\ o=ba\,r value=20.000000
+device_frmpayload_data_status,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\ o=ba\,r value="on"
+device_frmpayload_data_temperature,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\ o=ba\,r value=25.400000
+device_uplink,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,dr=2,fo\ o=ba\,r,frequency=868100000 f_cnt=10i,value=1i`,
+		},
+		{
+			Name: "One level depth with nil value",
+			Payload: pb.UplinkEvent{
+				ApplicationName: "test-app",
+				DeviceName:      "test-dev",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				FCnt:            10,
+				FPort:           20,
+				Dr:              2,
+				TxInfo: &gw.UplinkTXInfo{
+					Frequency: 868100000,
+				},
+				ObjectJson: `{
+					"temperature": null,
+					"humidity":    20,
+					"active":      true,
+					"status":      "on"
+				}`,
+				Tags: map[string]string{
+					"fo=o": "bar",
+				},
+			},
+			ExpectedBody: `device_frmpayload_data_active,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\=o=bar value=true
+device_frmpayload_data_humidity,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\=o=bar value=20.000000
+device_frmpayload_data_status,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,fo\=o=bar value="on"
+device_uplink,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,dr=2,fo\=o=bar,frequency=868100000 f_cnt=10i,value=1i`,
+		},
+		{
+			Name: "One level depth + RXInfo",
+			Payload: pb.UplinkEvent{
+				ApplicationName: "test-app",
+				DeviceName:      "test-dev",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				FCnt:            10,
+				FPort:           20,
+				Dr:              2,
+				TxInfo: &gw.UplinkTXInfo{
+					Frequency: 868100000,
+				},
+				RxInfo: []*gw.UplinkRXInfo{
+					{
+						LoraSnr: 1,
+						Rssi:    -60,
+					},
+					{
+						LoraSnr: 2.5,
+						Rssi:    -55,
+					},
+					{
+						LoraSnr: 1,
+						Rssi:    -70,
+					},
+				},
+				ObjectJson: `{
+					"temperature": 25.4,
+					"humidity":    20,
+					"active":      true,
+					"status":      "on"
+				}`,
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			ExpectedBody: `device_frmpayload_data_active,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=true
+device_frmpayload_data_humidity,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=20.000000
+device_frmpayload_data_status,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value="on"
+device_frmpayload_data_temperature,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=25.400000
+device_uplink,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,dr=2,foo=bar,frequency=868100000 f_cnt=10i,rssi=-55i,snr=2.500000,value=1i`,
+		},
+		{
+			Name: "Mixed level depth",
+			Payload: pb.UplinkEvent{
+				ApplicationName: "test-app",
+				DeviceName:      "test-dev",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				FCnt:            10,
+				FPort:           20,
+				Dr:              2,
+				TxInfo: &gw.UplinkTXInfo{
+					Frequency: 868100000,
+				},
+				ObjectJson: `{
+					"temperature": {
+						"a": 20.5,
+						"b": 33.3
+					},
+					"humidity": 20,
+					"active":   true,
+					"status":   "on"
+				}`,
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			ExpectedBody: `device_frmpayload_data_active,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=true
+device_frmpayload_data_humidity,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=20.000000
+device_frmpayload_data_status,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value="on"
+device_frmpayload_data_temperature_a,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=20.500000
+device_frmpayload_data_temperature_b,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=33.300000
+device_uplink,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,dr=2,foo=bar,frequency=868100000 f_cnt=10i,value=1i`,
+		},
+		{
+			Name: "One level depth + device status fields",
+			Payload: pb.UplinkEvent{
+				ApplicationName: "test-app",
+				DeviceName:      "test-dev",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				FCnt:            10,
+				FPort:           20,
+				Dr:              2,
+				TxInfo: &gw.UplinkTXInfo{
+					Frequency: 868100000,
+				},
+				ObjectJson: `{
+					"temperature": 25.4,
+					"humidity":    20,
+					"active":      true,
+					"status":      "on"
+				}`,
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			ExpectedBody: `device_frmpayload_data_active,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=true
+device_frmpayload_data_humidity,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=20.000000
+device_frmpayload_data_status,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value="on"
+device_frmpayload_data_temperature,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=25.400000
+device_uplink,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,dr=2,foo=bar,frequency=868100000 f_cnt=10i,value=1i`,
+		},
+		{
+			Name: "Latitude and longitude",
+			Payload: pb.UplinkEvent{
+				ApplicationName: "test-app",
+				DeviceName:      "test-dev",
+				DevEui:          []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				FCnt:            10,
+				FPort:           20,
+				Dr:              2,
+				TxInfo: &gw.UplinkTXInfo{
+					Frequency: 868100000,
+				},
+				ObjectJson: `{
+					"latitude":  1.123,
+					"longitude": 2.123,
+					"active":    true,
+					"status":    "on"
+				}`,
+				Tags: map[string]string{
+					"foo": "bar",
+				},
+			},
+			ExpectedBody: `device_frmpayload_data_active,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value=true
+device_frmpayload_data_location,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar geohash="s01w2k3vvqre",latitude=1.123000,longitude=2.123000
+device_frmpayload_data_status,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,f_port=20,foo=bar value="on"
+device_uplink,application_name=test-app,dev_eui=0102030405060708,device_name=test-dev,dr=2,foo=bar,frequency=868100000 f_cnt=10i,value=1i`,
+		},
+	}
+
+	for _, tst := range tests {
+		ts.T().Run(tst.Name, func(t *testing.T) {
+			assert := require.New(t)
+			assert.NoError(ts.Handler.HandleUplinkEvent(context.Background(), nil, nil, tst.Payload))
+			req := <-ts.Requests
+			assert.Equal("/write", req.URL.Path)
+			assert.Equal(url.Values{
+				"db":        []string{"chirpstack"},
+				"precision": []string{"s"},
+				"rp":        []string{"DEFAULT"},
+			}, req.URL.Query())
+
+			b, err := ioutil.ReadAll(req.Body)
+			assert.NoError(err)
+			assert.Equal(tst.ExpectedBody, string(b))
+
+			user, pw, ok := req.BasicAuth()
+			assert.Equal("user", user)
+			assert.Equal("password", pw)
+			assert.True(ok)
+
+			assert.Equal("text/plain", req.Header.Get("Content-Type"))
+		})
+	}
+}
+
+func TestHandler(t *testing.T) {
+	suite.Run(t, new(HandlerTestSuite))
+}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brocaar/chirpstack-application-server/internal/integration/gcppubsub"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/http"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/influxdb"
+	"github.com/brocaar/chirpstack-application-server/internal/integration/influxdbv2"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/kafka"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/logger"
 	"github.com/brocaar/chirpstack-application-server/internal/integration/loracloud"
@@ -34,6 +35,7 @@ import (
 const (
 	HTTP            = "HTTP"
 	InfluxDB        = "INFLUXDB"
+	InfluxDBV2		= "INFLUXDBV2"
 	ThingsBoard     = "THINGSBOARD"
 	MyDevices       = "MYDEVICES"
 	LoRaCloud       = "LORACLOUD"
@@ -167,6 +169,18 @@ func ForApplicationID(id int64) models.Integration {
 
 			// create new influxdb integration
 			i, err = influxdb.New(conf)
+		case InfluxDBV2:
+			// read config
+			var conf influxdbv2.Config
+			if err := json.NewDecoder(bytes.NewReader(appint.Settings)).Decode(&conf); err != nil {
+				log.WithError(err).WithFields(log.Fields{
+					"application_id": id,
+				}).Error("integrations: read influxdbv2 configuration error")
+				continue
+			}
+
+			// create new influxdbv2 integration
+			i, err = influxdbv2.New(conf)
 		case ThingsBoard:
 			// read config
 			var conf thingsboard.Config

--- a/ui/src/stores/ApplicationStore.js
+++ b/ui/src/stores/ApplicationStore.js
@@ -1,9 +1,9 @@
-import { EventEmitter } from "events";
+import {EventEmitter} from "events";
 
 import Swagger from "swagger-client";
 
 import sessionStore from "./SessionStore";
-import {checkStatus, errorHandler } from "./helpers";
+import {checkStatus, errorHandler} from "./helpers";
 import dispatcher from "../dispatcher";
 
 
@@ -165,65 +165,81 @@ class ApplicationStore extends EventEmitter {
     });
   }
 
-  createInfluxDBIntegration(integration, callbackFunc) {
+  createInfluxDBIntegration(integration, callbackFunc, v2 = false) {
+    let data = {
+      "integration.application_id": integration.applicationID,
+      body: {
+        integration: integration,
+      },
+    };
+
     this.swagger.then(client => {
-      client.apis.ApplicationService.CreateInfluxDBIntegration({
-        "integration.application_id": integration.applicationID,
-        body: {
-          integration: integration,
-        },
-      })
-      .then(checkStatus)
-      .then(resp => {
-        this.integrationNotification("InfluxDB", "created");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+      let promise = v2 ? client.apis.ApplicationService.CreateInfluxDBV2Integration(data)
+          : client.apis.ApplicationService.CreateInfluxDBIntegration(data);
+
+      promise.then(checkStatus)
+          .then(resp => {
+            this.integrationNotification("InfluxDB", "created");
+            callbackFunc(resp.obj);
+          })
+          .catch(errorHandler);
     });
   }
 
-  getInfluxDBIntegration(applicationID, callbackFunc) {
+  getInfluxDBIntegration(applicationID, callbackFunc, v2 = false) {
+    let data = {
+      application_id: applicationID,
+    };
+
     this.swagger.then(client => {
-      client.apis.ApplicationService.GetInfluxDBIntegration({
-        application_id: applicationID,
-      })
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+      let promise = v2 ? client.apis.ApplicationService.GetInfluxDBV2Integration(data)
+          : client.apis.ApplicationService.GetInfluxDBIntegration(data);
+
+      promise.then(checkStatus)
+          .then(resp => {
+            callbackFunc(resp.obj);
+          })
+          .catch(errorHandler);
     });
   }
 
-  updateInfluxDBIntegration(integration, callbackFunc) {
+  updateInfluxDBIntegration(integration, callbackFunc, v2 = false) {
+    let data = {
+      "integration.application_id": integration.applicationID,
+      body: {
+        integration: integration,
+      },
+    };
+
     this.swagger.then(client => {
-      client.apis.ApplicationService.UpdateInfluxDBIntegration({
-        "integration.application_id": integration.applicationID,
-        body: {
-          integration: integration,
-        },
-      })
-      .then(checkStatus)
-      .then(resp => {
-        this.integrationNotification("InfluxDB", "updated");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+      let promise = v2 ? client.apis.ApplicationService.UpdateInfluxDBV2Integration(data)
+          : client.apis.ApplicationService.UpdateInfluxDBIntegration(data);
+
+      promise.then(checkStatus)
+          .then(resp => {
+            this.integrationNotification("InfluxDB", "updated");
+            callbackFunc(resp.obj);
+          })
+          .catch(errorHandler);
     });
   }
 
-  deleteInfluxDBIntegration(applicationID, callbackFunc) {
+  deleteInfluxDBIntegration(applicationID, callbackFunc, v2 = false) {
+    let data = {
+      application_id: applicationID,
+    };
+
     this.swagger.then(client => {
-      client.apis.ApplicationService.DeleteInfluxDBIntegration({
-        application_id: applicationID,
-      })
-      .then(checkStatus)
-      .then(resp => {
-        this.integrationNotification("InfluxDB", "deleted");
-        this.emit("integration.delete");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+      let promise = v2 ? client.apis.ApplicationService.DeleteInfluxDBV2Integration(data)
+          : client.apis.ApplicationService.DeleteInfluxDBIntegration(data);
+
+      promise.then(checkStatus)
+          .then(resp => {
+            this.integrationNotification("InfluxDB", "deleted");
+            this.emit("integration.delete");
+            callbackFunc(resp.obj);
+          })
+          .catch(errorHandler);
     });
   }
 

--- a/ui/src/views/applications/ApplicationLayout.js
+++ b/ui/src/views/applications/ApplicationLayout.js
@@ -177,6 +177,7 @@ class ApplicationLayout extends Component {
             <Route exact path={`${this.props.match.path}/integrations/azure-service-bus/edit`} render={props => <UpdateAzureServiceBusIntegration {...props} />} />
             <Route exact path={`${this.props.match.path}/integrations/influxdb/create`} render={props => <CreateInfluxDBIntegration {...props} />} />
             <Route exact path={`${this.props.match.path}/integrations/influxdb/edit`} render={props => <UpdateInfluxDBIntegration {...props} />} />
+            <Route exact path={`${this.props.match.path}/integrations/influxdbv2/edit`} render={props => <UpdateInfluxDBIntegration {...props} V2/>} />
             <Route exact path={`${this.props.match.path}/integrations/thingsboard/create`} render={props => <CreateThingsBoardIntegration {...props} />} />
             <Route exact path={`${this.props.match.path}/integrations/thingsboard/edit`} render={props => <UpdateThingsBoardIntegration {...props} />} />
             <Route exact path={`${this.props.match.path}/integrations/loracloud/create`} render={props => <CreateLoRaCloudIntegration {...props} />} />

--- a/ui/src/views/applications/ListIntegrations.js
+++ b/ui/src/views/applications/ListIntegrations.js
@@ -105,7 +105,9 @@ class ListIntegrations extends Component {
 
       // InfluxDB
       if(includes(resp.result, "INFLUXDB")) {
-        configured.push(<InfluxDBCard organizationID={organizationID} applicationID={applicationID} />);
+        configured.push(<InfluxDBCard organizationID={organizationID} applicationID={applicationID}/>);
+      } else if (includes(resp.result, "INFLUXDBV2") ){
+          configured.push(<InfluxDBCard organizationID={organizationID} applicationID={applicationID} V2 />);
       } else {
         available.push(<InfluxDBCard organizationID={organizationID} applicationID={applicationID} add />);
       }

--- a/ui/src/views/applications/integrations/CreateInfluxDBIntegration.js
+++ b/ui/src/views/applications/integrations/CreateInfluxDBIntegration.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, {Component} from "react";
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
 import CardHeader from "@material-ui/core/CardHeader";
@@ -6,17 +6,32 @@ import CardContent from "@material-ui/core/CardContent";
 
 import ApplicationStore from "../../../stores/ApplicationStore";
 import InfluxDBIntegrationForm from "./InfluxDBIntegrationForm";
+import InfluxDBV2IntegrationForm from "./InfluxDBV2IntegrationForm";
+import Switch from '@material-ui/core/Switch';
+import Form from "../../../components/Form";
+import FormLabel from "@material-ui/core/FormLabel";
 
 
 class CreateInfluxDBIntegration extends Component {
+  constructor(props) {
+    super(props)
+    this.state ={
+      V2: false
+    }
+  }
+
   onSubmit = (integration) => {
     let integr = integration;
     integr.applicationID = this.props.match.params.applicationID;
 
     ApplicationStore.createInfluxDBIntegration(integr, resp => {
       this.props.history.push(`/organizations/${this.props.match.params.organizationID}/applications/${this.props.match.params.applicationID}/integrations`);
-    });
-  } 
+    }, this.state.V2);
+  }
+
+  handleChange=(ev)=>{
+    this.setState({V2: !this.state.V2})
+  }
 
   render() {
     return(
@@ -25,7 +40,15 @@ class CreateInfluxDBIntegration extends Component {
           <Card>
             <CardHeader title="Add InfluxDB integration" />
             <CardContent>
-              <InfluxDBIntegrationForm submitLabel="Add integration" onSubmit={this.onSubmit} />
+              <Form>
+                <FormLabel>InfluxDB v2+</FormLabel>
+                <Switch id="version" checked={this.state.V2} onChange={this.handleChange}/>
+              </Form>
+              <hr/>
+              {this.state.V2 ?
+                    <InfluxDBV2IntegrationForm submitLabel="Add integration" onSubmit={this.onSubmit}/>
+                    : <InfluxDBIntegrationForm submitLabel="Add integration" onSubmit={this.onSubmit}/>
+                }
             </CardContent>
           </Card>
         </Grid>

--- a/ui/src/views/applications/integrations/InfluxDBCard.js
+++ b/ui/src/views/applications/integrations/InfluxDBCard.js
@@ -23,7 +23,7 @@ const styles = {
 class InfluxDBCard extends Component {
   delete = () => {
     if (window.confirm("Are you sure you want to remove the InfluxDB integration?")) {
-      ApplicationStore.deleteInfluxDBIntegration(this.props.applicationID, () => {});
+      ApplicationStore.deleteInfluxDBIntegration(this.props.applicationID, () => {}, this.props.V2);
     }
   }
 
@@ -44,7 +44,8 @@ class InfluxDBCard extends Component {
           </Typography>
         </CardContent>
         <CardActions>
-          {!this.props.add && <Link to={`/organizations/${this.props.organizationID}/applications/${this.props.applicationID}/integrations/influxdb/edit`}>
+          {!this.props.add && <Link
+              to={`/organizations/${this.props.organizationID}/applications/${this.props.applicationID}/integrations/${this.props.V2 ? "influxdbv2" : "influxdb"}/edit`}>
             <Button size="small" color="primary">
               Edit
             </Button>

--- a/ui/src/views/applications/integrations/InfluxDBV2IntegrationForm.js
+++ b/ui/src/views/applications/integrations/InfluxDBV2IntegrationForm.js
@@ -1,0 +1,99 @@
+import React from "react";
+
+import { withStyles } from "@material-ui/core/styles";
+import FormControl from "@material-ui/core/FormControl";
+import FormLabel from "@material-ui/core/FormLabel";
+import TextField from '@material-ui/core/TextField';
+import FormHelperText from "@material-ui/core/FormHelperText";
+
+import FormComponent from "../../../classes/FormComponent";
+import Form from "../../../components/Form";
+import AutocompleteSelect from "../../../components/AutocompleteSelect";
+
+
+const styles = {
+  formLabel: {
+    fontSize: 12,
+  },
+};
+
+
+class InfluxDBV2IntegrationForm extends FormComponent {
+  getPrecisionOptions(search, callbackFunc) {
+    const precisionOptions = [
+      {value: "NS", label: "Nanosecond"},
+      {value: "U", label: "Microsecond"},
+      {value: "MS", label: "Millisecond"},
+      {value: "S", label: "Second"},
+      {value: "M", label: "Minute"},
+      {value: "H", label: "Hour"},
+    ];
+
+    callbackFunc(precisionOptions);
+  }
+
+  render() {
+    if (this.state.object === undefined) {
+      return null;
+    }
+
+    // onSubmit={this.onSubmit}>
+    return(
+      <Form submitLabel={this.props.submitLabel} onSubmit={this.onSubmit} >
+        <TextField
+          id="host"
+          label="Host"
+          placeholder="http://localhost:8086"
+          value={this.state.object.host || ""}
+          onChange={this.onChange}
+          margin="normal"
+          required
+          fullWidth
+        />
+        <TextField
+          id="org"
+          label="Organisation"
+          value={this.state.object.org || ""}
+          onChange={this.onChange}
+          margin="normal"
+          required
+          fullWidth
+        />
+        <TextField
+          id="bucket"
+          label="Bucket"
+          value={this.state.object.bucket || ""}
+          onChange={this.onChange}
+          margin="normal"
+          required
+          fullWidth
+        />
+        <TextField
+          id="token"
+          label="Token"
+          value={this.state.object.token || ""}
+          onChange={this.onChange}
+          margin="normal"
+          type="password"
+          required
+          fullWidth
+        />
+        <FormControl fullWidth margin="normal">
+          <FormLabel className={this.props.classes.formLabel} required>Timestamp precision</FormLabel>
+          <AutocompleteSelect
+            id="precision"
+            label="Select timestamp precision"
+            value={this.state.object.precision || ""}
+            onChange={this.onChange}
+            getOptions={this.getPrecisionOptions}
+          />
+          <FormHelperText>
+            It is recommented to use the least precise precision possible as this can result in significant improvements in compression.
+          </FormHelperText>
+        </FormControl>
+      </Form>
+    );
+  }
+}
+
+export default withStyles(styles)(InfluxDBV2IntegrationForm);

--- a/ui/src/views/applications/integrations/UpdateInfluxDBIntegration.js
+++ b/ui/src/views/applications/integrations/UpdateInfluxDBIntegration.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, {Component} from "react";
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
 import CardHeader from "@material-ui/core/CardHeader";
@@ -6,12 +6,12 @@ import CardContent from "@material-ui/core/CardContent";
 
 import ApplicationStore from "../../../stores/ApplicationStore";
 import InfluxDBIntegrationForm from "./InfluxDBIntegrationForm";
+import InfluxDBV2IntegrationForm from "./InfluxDBV2IntegrationForm";
 
 
 class UpdateInfluxDBIntegration extends Component {
   constructor() {
     super();
-
     this.state = {};
   }
 
@@ -21,7 +21,7 @@ class UpdateInfluxDBIntegration extends Component {
 
     ApplicationStore.updateInfluxDBIntegration(integr, resp => {
       this.props.history.push(`/organizations/${this.props.match.params.organizationID}/applications/${this.props.match.params.applicationID}/integrations`);
-    });
+    }, this.props.V2);
   } 
 
   componentDidMount() {
@@ -29,7 +29,7 @@ class UpdateInfluxDBIntegration extends Component {
       this.setState({
         object: resp.integration,
       });
-    });
+    }, this.props.V2);
   }
 
   render() {
@@ -43,7 +43,10 @@ class UpdateInfluxDBIntegration extends Component {
           <Card>
             <CardHeader title="Update InfluxDB integration" />
             <CardContent>
-              <InfluxDBIntegrationForm submitLabel="Update integration" onSubmit={this.onSubmit} object={this.state.object} />
+              {this.props.V2 ?
+                  <InfluxDBV2IntegrationForm submitLabel="Update integration" onSubmit={this.onSubmit} object={this.state.object}/>
+                  : <InfluxDBIntegrationForm submitLabel="Update integration" onSubmit={this.onSubmit} object={this.state.object}/>
+              }
             </CardContent>
           </Card>
         </Grid>


### PR DESCRIPTION
Depends on https://github.com/brocaar/chirpstack-api/pull/39

Resolves #409

I reused (read blatantly copied and pasted) a lot from V1 because the underlying protocol is same, only the way to connect to the database is different, I tried to make this visible by having that one commit with just pasted content so the next commit with the real feature has some sensible diff.
Maybe there is some way to reuse for example the go tests but I couldn't how to do it without exporting like almost whole file. It was simply more time efficient to copy paste the code instead of trying to find a way to extend the existing code (especially within go).

On frontend it's under the same integration (though within backend it is a different integration, so if needed these could be split so one application can have both V1 and V2 added)
![image](https://user-images.githubusercontent.com/8504482/115775785-963d3800-a3b3-11eb-8a87-ab579f4879f9.png)

