### PR TITLE
Fix "gatewayID" hex converter in lorawan frames.

### DIFF
--- a/ui/src/components/JSONTree.js
+++ b/ui/src/components/JSONTree.js
@@ -29,6 +29,7 @@ class JSONTree extends Component {
 
     // :(
     let data = JSON.parse(JSON.stringify(this.props.data));
+    let type = this.props.eventType;
 
     if ("devEUI" in data && data.devEUI !== null) {
       data.devEUI = base64ToHex(data.devEUI);
@@ -38,7 +39,7 @@ class JSONTree extends Component {
       data.devAddr = base64ToHex(data.devAddr);
     }
 
-    if ("gatewayID" in data && data.gatewayID !== null) {
+    if ("gatewayID" in data && data.gatewayID !== null && type === "txack") {
       data.gatewayID = base64ToHex(data.gatewayID);
     }
 

--- a/ui/src/views/devices/DeviceData.js
+++ b/ui/src/views/devices/DeviceData.js
@@ -137,7 +137,7 @@ class DeviceDataItem extends Component {
         <ExpansionPanelDetails>
           <Grid container spacing={4}>
             {this.state.expanded && <Grid item xs className={this.props.classes.treeStyle}>
-              <JSONTree data={this.props.data.payload} />
+              <JSONTree data={this.props.data.payload} eventType={this.props.data.type} />
             </Grid>}
           </Grid>
         </ExpansionPanelDetails>
@@ -222,8 +222,6 @@ class DeviceData extends Component {
     if (this.state.paused) {
       return;
     }
-
-    console.log('data: ', d);
 
     let data = this.state.data;
     const now = new Date();


### PR DESCRIPTION
`gatewayID` also convert to base64ToHex in the lorawan frames tabs as it's already in HEX format. It was not shown properly due to `TxAck`  `gatewayID` base64ToHex conversion in JSONTree.js.

see attached screenshot for your reference.
![fix-gatewayid-hex](https://user-images.githubusercontent.com/43664335/122213492-a7438a80-cec6-11eb-80ec-f13991bc4921.jpeg)
