### PR TITLE
Fetch OpenID Connect claims with UserInfo call, not id_token, and pass claims to registration callback url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH=$PATH:$PROJECT_PATH/build
 ENV CGO_ENABLED=0
 ENV GO_EXTRA_BUILD_ARGS="-a -installsuffix cgo"
 
-RUN apk add --no-cache ca-certificates make git bash alpine-sdk nodejs nodejs-npm
+RUN apk add --no-cache ca-certificates make git bash alpine-sdk nodejs npm
 
 RUN mkdir -p $PROJECT_PATH
 COPY . $PROJECT_PATH

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -5,7 +5,7 @@ ENV PATH=$PATH:$PROJECT_PATH/build
 ENV CGO_ENABLED=0
 ENV GO_EXTRA_BUILD_ARGS="-a -installsuffix cgo"
 
-RUN apk add --no-cache ca-certificates make git bash alpine-sdk nodejs nodejs-npm rpm protobuf
+RUN apk add --no-cache ca-certificates make git bash alpine-sdk nodejs npm rpm protobuf
 
 RUN git clone https://github.com/protocolbuffers/protobuf.git /protobuf
 

--- a/internal/api/external/internal.go
+++ b/internal/api/external/internal.go
@@ -321,6 +321,11 @@ func (a *InternalAPI) OpenIDConnectLogin(ctx context.Context, req *pb.OpenIDConn
 					if err != nil {
 						return nil, helpers.ErrToRPCError(err)
 					}
+					// fetch user again because the provisioning callback url may have updated the user.
+					user, err = storage.GetUser(ctx, storage.DB(), user.ID)
+					if err != nil {
+						return nil, helpers.ErrToRPCError(err)
+					}
 				} else {
 					return nil, helpers.ErrToRPCError(err)
 				}

--- a/internal/api/external/internal.go
+++ b/internal/api/external/internal.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -412,7 +413,7 @@ func (a *InternalAPI) createAndProvisionUser(ctx context.Context, user oidc.User
 		return u, nil
 	}
 
-	if err := a.provisionUser(ctx, u); err != nil {
+	if err := a.provisionUser(ctx, u, user); err != nil {
 		if err := storage.DeleteUser(ctx, storage.DB(), u.ID); err != nil {
 			return storage.User{}, errors.Wrap(err, "delete user error after failed user provisioning")
 		}
@@ -425,13 +426,18 @@ func (a *InternalAPI) createAndProvisionUser(ctx context.Context, user oidc.User
 	return u, nil
 }
 
-func (a *InternalAPI) provisionUser(ctx context.Context, u storage.User) error {
+func (a *InternalAPI) provisionUser(ctx context.Context, u storage.User, oidcUser oidc.User) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", registrationCallbackURL, nil)
 	if err != nil {
 		return errors.Wrap(err, "new request error")
 	}
 	q := req.URL.Query()
 	q.Add("user_id", fmt.Sprintf("%d", u.ID))
+	claims, err := json.Marshal(oidcUser.UserInfoClaims)
+	if err != nil {
+		return errors.Wrap(err, "marshal claims error")
+	}
+	q.Add("oidc_claims", string(claims))
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
The OpenID Connect ("OIDC") login method currently attempts to fetch "claims" from the "id_token". However, it's optional for OIDC servers to put claims in that field. Certainly by default not all auth servers do that. You can request it with a "claims requested" field, but implementing that feature is optional for OIDC servers. Instead, the safer mechanism for fetching all claims seems to be a separate "userinfo" call. This change makes that call.

This change also passes the claims on to the registration callback url, as field "oidc_claims", in JSON. A separate provisioning tool can then use the claims to configure the user properly, eg assign them to an organization.

This change also makes sure that any changes to the user by the registration callback url are not overwritten when the email fields are updated. For example, I was setting the "note" field in the user, and was wondering why it got lost.

Perhaps the oidc_claims should be documented somewhere?
