### PR TITLE
http-integrations: switched from default http.client to http client with timeout

### DIFF
--- a/internal/integration/http/http.go
+++ b/internal/integration/http/http.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ type Config struct {
 	Headers          map[string]string `json:"headers"`
 	EventEndpointURL string            `json:"eventEndpointURL"`
 	Marshaler        string            `json:"marshaler"`
+	Timeout          int64             `json:"timeout"` // Milliseconds
 
 	// For backwards compatibility.
 	DataUpURL                  string `json:"dataUpURL"`
@@ -69,6 +71,10 @@ func New(m marshaler.Type, conf Config) (*Integration, error) {
 		}
 	}
 
+	if conf.Timeout == 0 {
+		conf.Timeout = 10000
+	}
+
 	return &Integration{
 		marshaler: m,
 		config:    conf,
@@ -96,7 +102,11 @@ func (i *Integration) send(u string, msg proto.Message) error {
 		req.Header.Set(k, v)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		Timeout: time.Millisecond * time.Duration(i.config.Timeout),
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "http request error")
 	}

--- a/internal/integration/http/http.go
+++ b/internal/integration/http/http.go
@@ -29,7 +29,7 @@ type Config struct {
 	Headers          map[string]string `json:"headers"`
 	EventEndpointURL string            `json:"eventEndpointURL"`
 	Marshaler        string            `json:"marshaler"`
-	Timeout          int64             `json:"timeout"` // Milliseconds
+	Timeout          time.Duration     `json:"timeout"`
 
 	// For backwards compatibility.
 	DataUpURL                  string `json:"dataUpURL"`
@@ -72,7 +72,7 @@ func New(m marshaler.Type, conf Config) (*Integration, error) {
 	}
 
 	if conf.Timeout == 0 {
-		conf.Timeout = 10000
+		conf.Timeout = time.Second * 10
 	}
 
 	return &Integration{
@@ -103,7 +103,7 @@ func (i *Integration) send(u string, msg proto.Message) error {
 	}
 
 	client := &http.Client{
-		Timeout: time.Millisecond * time.Duration(i.config.Timeout),
+		Timeout: i.config.Timeout,
 	}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
It's not recommended to use defaultClient in production, as it has no timeout at all. So if http-integration far-end application keeps holding all connections - it may lead to out of entire service. For instance when the number of connections reaches max open files, allowed by host-system (for example systemd allows 1024 max files by default). Custom timeout value can be implemented for each intergation configuration in future.