### PR TITLE
Extendes UplinkEvent with DeviceProfileName, DeviceProfileUUID and its Tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
 	github.com/aws/aws-sdk-go v1.26.3
-	github.com/brocaar/chirpstack-api/go/v3 v3.11.1
+	github.com/brocaar/chirpstack-api/go/v3 v3.12.4
 	github.com/brocaar/lorawan v0.0.0-20210809075358-95fc1667572e
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/brocaar/chirpstack-api/go/v3 v3.11.1 h1:/CpPFxvaNcF0yEE+Y0t2BJF529sciIMTsK/Wx565Z7c=
-github.com/brocaar/chirpstack-api/go/v3 v3.11.1/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
+github.com/brocaar/chirpstack-api/go/v3 v3.12.4 h1:D0/TJrtckPByXUB399ZQ0wUsp9mB+LNI5AxQp8DWYj0=
+github.com/brocaar/chirpstack-api/go/v3 v3.12.4/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
 github.com/brocaar/lorawan v0.0.0-20210809075358-95fc1667572e h1:htxGGoTtAoy4p3qnq42qb0GfupCLe2AXJkSqzLYEPnA=
 github.com/brocaar/lorawan v0.0.0-20210809075358-95fc1667572e/go.mod h1:Vlf3gOwizqX4y3snWe/i2EqRT83HvYuwBjRu39PevW0=
 github.com/caarlos0/ctrlc v1.0.0 h1:2DtF8GSIcajgffDFJzyG15vO+1PuBWOMUdFut7NnXhw=
@@ -351,7 +351,6 @@ github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/internal/api/as/as_test.go
+++ b/internal/api/as/as_test.go
@@ -323,9 +323,11 @@ func (ts *ASTestSuite) TestApplicationServer() {
 					Tags: map[string]string{
 						"foo": "bar",
 					},
-					ConfirmedUplink: true,
-					DevAddr:         d.DevAddr[:],
-					PublishedAt:     pl.PublishedAt,
+					ConfirmedUplink:   true,
+					DevAddr:           d.DevAddr[:],
+					PublishedAt:       pl.PublishedAt,
+					DeviceProfileId:   dpID.String(),
+					DeviceProfileName: dp.Name,
 				}, pl)
 			})
 

--- a/internal/events/uplink/uplink.go
+++ b/internal/events/uplink/uplink.go
@@ -251,7 +251,7 @@ func handleIntegrations(ctx *uplinkContext) error {
 	pl := pb.UplinkEvent{
 		ApplicationId:     uint64(ctx.device.ApplicationID),
 		ApplicationName:   ctx.application.Name,
-		DeviceProfileUuid: ctx.device.DeviceProfileID.String(),
+		DeviceProfileId:   ctx.device.DeviceProfileID.String(),
 		DeviceProfileName: ctx.deviceProfile.Name,
 		DeviceName:        ctx.device.Name,
 		DevEui:            ctx.device.DevEUI[:],

--- a/internal/events/uplink/uplink.go
+++ b/internal/events/uplink/uplink.go
@@ -249,22 +249,31 @@ func handleCodec(ctx *uplinkContext) error {
 
 func handleIntegrations(ctx *uplinkContext) error {
 	pl := pb.UplinkEvent{
-		ApplicationId:   uint64(ctx.device.ApplicationID),
-		ApplicationName: ctx.application.Name,
-		DeviceName:      ctx.device.Name,
-		DevEui:          ctx.device.DevEUI[:],
-		RxInfo:          ctx.uplinkDataReq.RxInfo,
-		TxInfo:          ctx.uplinkDataReq.TxInfo,
-		Dr:              ctx.uplinkDataReq.Dr,
-		Adr:             ctx.uplinkDataReq.Adr,
-		FCnt:            ctx.uplinkDataReq.FCnt,
-		FPort:           ctx.uplinkDataReq.FPort,
-		Data:            ctx.data,
-		ObjectJson:      ctx.objectJSON,
-		Tags:            make(map[string]string),
-		ConfirmedUplink: ctx.uplinkDataReq.ConfirmedUplink,
-		DevAddr:         ctx.device.DevAddr[:],
-		PublishedAt:     ptypes.TimestampNow(),
+		ApplicationId:     uint64(ctx.device.ApplicationID),
+		ApplicationName:   ctx.application.Name,
+		DeviceProfileUuid: ctx.device.DeviceProfileID.String(),
+		DeviceProfileName: ctx.deviceProfile.Name,
+		DeviceName:        ctx.device.Name,
+		DevEui:            ctx.device.DevEUI[:],
+		RxInfo:            ctx.uplinkDataReq.RxInfo,
+		TxInfo:            ctx.uplinkDataReq.TxInfo,
+		Dr:                ctx.uplinkDataReq.Dr,
+		Adr:               ctx.uplinkDataReq.Adr,
+		FCnt:              ctx.uplinkDataReq.FCnt,
+		FPort:             ctx.uplinkDataReq.FPort,
+		Data:              ctx.data,
+		ObjectJson:        ctx.objectJSON,
+		Tags:              make(map[string]string),
+		ConfirmedUplink:   ctx.uplinkDataReq.ConfirmedUplink,
+		DevAddr:           ctx.device.DevAddr[:],
+		PublishedAt:       ptypes.TimestampNow(),
+	}
+
+	//set device profile tags
+	for k, v := range ctx.deviceProfile.Tags.Map {
+		if v.Valid {
+			pl.Tags[k] = v.String
+		}
 	}
 
 	// set tags

--- a/internal/integration/marshaler/marshaler.go
+++ b/internal/integration/marshaler/marshaler.go
@@ -100,9 +100,11 @@ func jsonv3MarshalUplinkEvent(msg *integration.UplinkEvent) ([]byte, error) {
 	}
 
 	m := models.DataUpPayload{
-		ApplicationID:   int64(msg.ApplicationId),
-		ApplicationName: msg.ApplicationName,
-		DeviceName:      msg.DeviceName,
+		ApplicationID:     int64(msg.ApplicationId),
+		ApplicationName:   msg.ApplicationName,
+		DeviceName:        msg.DeviceName,
+		DeviceProfileName: msg.DeviceProfileName,
+		DeviceProfileUUID: msg.DeviceProfileUuid,
 		TXInfo: models.TXInfo{
 			Frequency: int(msg.TxInfo.Frequency),
 			DR:        int(msg.Dr),

--- a/internal/integration/marshaler/marshaler.go
+++ b/internal/integration/marshaler/marshaler.go
@@ -104,7 +104,7 @@ func jsonv3MarshalUplinkEvent(msg *integration.UplinkEvent) ([]byte, error) {
 		ApplicationName:   msg.ApplicationName,
 		DeviceName:        msg.DeviceName,
 		DeviceProfileName: msg.DeviceProfileName,
-		DeviceProfileUUID: msg.DeviceProfileUuid,
+		DeviceProfileID:   msg.DeviceProfileId,
 		TXInfo: models.TXInfo{
 			Frequency: int(msg.TxInfo.Frequency),
 			DR:        int(msg.Dr),

--- a/internal/integration/marshaler/marshaler_test.go
+++ b/internal/integration/marshaler/marshaler_test.go
@@ -46,10 +46,12 @@ func (ts *MarshalerTestSuite) GetUplinkEvent() integration.UplinkEvent {
 	tenSecondsPB := ptypes.DurationProto(tenSeconds)
 
 	return integration.UplinkEvent{
-		ApplicationId:   123,
-		ApplicationName: "test-application",
-		DeviceName:      "test-device",
-		DevEui:          []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		ApplicationId:     123,
+		ApplicationName:   "test-application",
+		DeviceName:        "test-device",
+		DeviceProfileName: "test-profile",
+		DeviceProfileId:   "f293e453-6d9c-4a22-8c4d-99b2dbe4e94f",
+		DevEui:            []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
 		RxInfo: []*gw.UplinkRXInfo{
 			{
 				GatewayId:         []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
@@ -293,10 +295,12 @@ func (ts *MarshalerTestSuite) TestJSONV3() {
 		assert.NoError(json.Unmarshal(b, &pl))
 
 		assert.Equal(models.DataUpPayload{
-			ApplicationID:   123,
-			ApplicationName: "test-application",
-			DeviceName:      "test-device",
-			DevEUI:          lorawan.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			ApplicationID:     123,
+			ApplicationName:   "test-application",
+			DeviceName:        "test-device",
+			DeviceProfileName: "test-profile",
+			DeviceProfileID:   "f293e453-6d9c-4a22-8c4d-99b2dbe4e94f",
+			DevEUI:            lorawan.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
 			RXInfo: []models.RXInfo{
 				{
 					GatewayID: lorawan.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},

--- a/internal/integration/models/models.go
+++ b/internal/integration/models/models.go
@@ -38,7 +38,7 @@ type DataUpPayload struct {
 	ApplicationName   string            `json:"applicationName"`
 	DeviceName        string            `json:"deviceName"`
 	DeviceProfileName string            `json:"deviceProfileName"`
-	DeviceProfileUUID string            `json:"deviceProfileUUID"`
+	DeviceProfileID   string            `json:"deviceProfileID"`
 	DevEUI            lorawan.EUI64     `json:"devEUI"`
 	RXInfo            []RXInfo          `json:"rxInfo,omitempty"`
 	TXInfo            TXInfo            `json:"txInfo"`

--- a/internal/integration/models/models.go
+++ b/internal/integration/models/models.go
@@ -34,19 +34,21 @@ type TXInfo struct {
 
 // DataUpPayload represents a data-up payload.
 type DataUpPayload struct {
-	ApplicationID   int64             `json:"applicationID,string"`
-	ApplicationName string            `json:"applicationName"`
-	DeviceName      string            `json:"deviceName"`
-	DevEUI          lorawan.EUI64     `json:"devEUI"`
-	RXInfo          []RXInfo          `json:"rxInfo,omitempty"`
-	TXInfo          TXInfo            `json:"txInfo"`
-	ADR             bool              `json:"adr"`
-	FCnt            uint32            `json:"fCnt"`
-	FPort           uint8             `json:"fPort"`
-	Data            []byte            `json:"data"`
-	Object          interface{}       `json:"object,omitempty"`
-	Tags            map[string]string `json:"tags,omitempty"`
-	Variables       map[string]string `json:"-"`
+	ApplicationID     int64             `json:"applicationID,string"`
+	ApplicationName   string            `json:"applicationName"`
+	DeviceName        string            `json:"deviceName"`
+	DeviceProfileName string            `json:"deviceProfileName"`
+	DeviceProfileUUID string            `json:"deviceProfileUUID"`
+	DevEUI            lorawan.EUI64     `json:"devEUI"`
+	RXInfo            []RXInfo          `json:"rxInfo,omitempty"`
+	TXInfo            TXInfo            `json:"txInfo"`
+	ADR               bool              `json:"adr"`
+	FCnt              uint32            `json:"fCnt"`
+	FPort             uint8             `json:"fPort"`
+	Data              []byte            `json:"data"`
+	Object            interface{}       `json:"object,omitempty"`
+	Tags              map[string]string `json:"tags,omitempty"`
+	Variables         map[string]string `json:"-"`
 }
 
 // DataDownPayload represents a data-down payload.


### PR DESCRIPTION
This will close #611 and #609 
- [x] `make test` ran successfully
- [x] Tested it with the network server stack via docker-compose


This also needs this pull request from chirpstack-api: https://github.com/brocaar/chirpstack-api/pull/47

As this pull request only adds two JSON fields it's **not** a breaking change