### PR TITLE
Add DevNonce Clear Functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
 	github.com/aws/aws-sdk-go v1.26.3
-	github.com/brocaar/chirpstack-api/go/v3 v3.12.4
+	github.com/brocaar/chirpstack-api/go/v3 v3.12.5
 	github.com/brocaar/lorawan v0.0.0-20211122090658-49524ce5fb5b
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.3.1
@@ -53,5 +53,3 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )
-
-replace github.com/brocaar/chirpstack-api/go/v3 => github.com/sagar-patel-sls/chirpstack-api-1/go/v3 v3.12.4-0.20220118060045-d63f79ed0de1

--- a/go.mod
+++ b/go.mod
@@ -54,4 +54,4 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )
 
-// replace github.com/brocaar/chirpstack-api/go/v3 => ../chirpstack-api/go
+replace github.com/brocaar/chirpstack-api/go/v3 => github.com/sagar-patel-sls/chirpstack-api-1/go/v3 v3.12.4-0.20220118060045-d63f79ed0de1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/brocaar/chirpstack-api/go/v3 v3.12.5 h1:sLV+zSZLUPnNCo2mf+gsw0ektbSiSHDvDn+RGs3ucgA=
+github.com/brocaar/chirpstack-api/go/v3 v3.12.5/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
 github.com/brocaar/lorawan v0.0.0-20211122090658-49524ce5fb5b h1:5cxv6403vkw54cjJMt2hVO5AZ8TdjD7emEWwJD++mYY=
 github.com/brocaar/lorawan v0.0.0-20211122090658-49524ce5fb5b/go.mod h1:Vlf3gOwizqX4y3snWe/i2EqRT83HvYuwBjRu39PevW0=
 github.com/caarlos0/ctrlc v1.0.0 h1:2DtF8GSIcajgffDFJzyG15vO+1PuBWOMUdFut7NnXhw=
@@ -455,8 +457,6 @@ github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/sagar-patel-sls/chirpstack-api-1/go/v3 v3.12.4-0.20220118060045-d63f79ed0de1 h1:iJGA4ULph57EHYJLbYCoxRlZGjGdcG4EmJuYxl/liXI=
-github.com/sagar-patel-sls/chirpstack-api-1/go/v3 v3.12.4-0.20220118060045-d63f79ed0de1/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/kafka-go v0.4.17 h1:IyqRstL9KUTDb3kyGPOOa5VffokKWSEzN6geJ92dSDY=
 github.com/segmentio/kafka-go v0.4.17/go.mod h1:19+Eg7KwrNKy/PFhiIthEPkO8k+ac7/ZYXwYM9Df10w=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,6 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2 h1:oMCHnXa6CCCafdPDbMh/lWRhRByN0VFLvv+g+ayx1SI=
 github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/brocaar/chirpstack-api/go/v3 v3.12.4 h1:D0/TJrtckPByXUB399ZQ0wUsp9mB+LNI5AxQp8DWYj0=
-github.com/brocaar/chirpstack-api/go/v3 v3.12.4/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
 github.com/brocaar/lorawan v0.0.0-20211122090658-49524ce5fb5b h1:5cxv6403vkw54cjJMt2hVO5AZ8TdjD7emEWwJD++mYY=
 github.com/brocaar/lorawan v0.0.0-20211122090658-49524ce5fb5b/go.mod h1:Vlf3gOwizqX4y3snWe/i2EqRT83HvYuwBjRu39PevW0=
 github.com/caarlos0/ctrlc v1.0.0 h1:2DtF8GSIcajgffDFJzyG15vO+1PuBWOMUdFut7NnXhw=
@@ -457,6 +455,8 @@ github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sagar-patel-sls/chirpstack-api-1/go/v3 v3.12.4-0.20220118060045-d63f79ed0de1 h1:iJGA4ULph57EHYJLbYCoxRlZGjGdcG4EmJuYxl/liXI=
+github.com/sagar-patel-sls/chirpstack-api-1/go/v3 v3.12.4-0.20220118060045-d63f79ed0de1/go.mod h1:v8AWP19nOJK4rwJsr1+weDfpUc4UNLbRh8Eygn4Oh00=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/kafka-go v0.4.17 h1:IyqRstL9KUTDb3kyGPOOa5VffokKWSEzN6geJ92dSDY=
 github.com/segmentio/kafka-go v0.4.17/go.mod h1:19+Eg7KwrNKy/PFhiIthEPkO8k+ac7/ZYXwYM9Df10w=

--- a/internal/backend/networkserver/mock/client.go
+++ b/internal/backend/networkserver/mock/client.go
@@ -149,6 +149,9 @@ type Client struct {
 	GetVersionResponse ns.GetVersionResponse
 
 	GetADRAlgorithmsResponse ns.GetADRAlgorithmsResponse
+
+	ClearDeviceNoncesChan     chan ns.ClearDeviceNoncesRequest
+	ClearDeviceNoncesResponse empty.Empty
 }
 
 // NewClient creates a new Client.
@@ -199,6 +202,7 @@ func NewClient() *Client {
 		FlushMulticastQueueForMulticastGroupChan:    make(chan ns.FlushMulticastQueueForMulticastGroupRequest, 100),
 		GetMulticastQueueItemsForMulticastGroupChan: make(chan ns.GetMulticastQueueItemsForMulticastGroupRequest, 100),
 		GenerateGatewayClientCertificateChan:        make(chan ns.GenerateGatewayClientCertificateRequest, 100),
+		ClearDeviceNoncesChan:                       make(chan ns.ClearDeviceNoncesRequest, 100),
 	}
 }
 
@@ -490,4 +494,10 @@ func (n *Client) GenerateGatewayClientCertificate(ctx context.Context, in *ns.Ge
 // GetADRAlgorithms method.
 func (n *Client) GetADRAlgorithms(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*ns.GetADRAlgorithmsResponse, error) {
 	return &n.GetADRAlgorithmsResponse, nil
+}
+
+// ClearDeviceNonces method.
+func (n *Client) ClearDeviceNonces(ctx context.Context, in *ns.ClearDeviceNoncesRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	n.ClearDeviceNoncesChan <- *in
+	return &n.ClearDeviceNoncesResponse, nil
 }

--- a/ui/src/stores/DeviceStore.js
+++ b/ui/src/stores/DeviceStore.js
@@ -4,9 +4,8 @@ import RobustWebSocket from "robust-websocket";
 import Swagger from "swagger-client";
 
 import sessionStore from "./SessionStore";
-import {checkStatus, errorHandler, errorHandlerIgnoreNotFoundWithCallback } from "./helpers";
+import { checkStatus, errorHandler, errorHandlerIgnoreNotFoundWithCallback } from "./helpers";
 import dispatcher from "../dispatcher";
-
 
 class DeviceStore extends EventEmitter {
   constructor() {
@@ -25,187 +24,200 @@ class DeviceStore extends EventEmitter {
   }
 
   create(device, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.Create({
         body: {
           device: device,
         },
       })
-      .then(checkStatus)
-      .then(resp => {
-        this.notify("created");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          this.notify("created");
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   get(id, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.Get({
         dev_eui: id,
       })
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   update(device, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.Update({
         "device.dev_eui": device.devEUI,
         body: {
           device: device,
         },
       })
-      .then(checkStatus)
-      .then(resp => {
-        this.emit("update");
-        this.notify("updated");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          this.emit("update");
+          this.notify("updated");
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
-
   }
 
   delete(id, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.Delete({
         dev_eui: id,
       })
-      .then(checkStatus)
-      .then(resp => {
-        this.notify("deleted");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          this.notify("deleted");
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   list(filters, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.List(filters)
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   getKeys(devEUI, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.GetKeys({
         dev_eui: devEUI,
       })
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandlerIgnoreNotFoundWithCallback(callbackFunc));
+        .then(checkStatus)
+        .then((resp) => {
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandlerIgnoreNotFoundWithCallback(callbackFunc));
     });
   }
 
   createKeys(deviceKeys, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.CreateKeys({
         "device_keys.dev_eui": deviceKeys.devEUI,
         body: {
           deviceKeys: deviceKeys,
         },
       })
-      .then(checkStatus)
-      .then(resp => {
-        this.notifyKeys("created");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          this.notifyKeys("created");
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   updateKeys(deviceKeys, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.UpdateKeys({
         "device_keys.dev_eui": deviceKeys.devEUI,
         body: {
           deviceKeys: deviceKeys,
         },
       })
-      .then(checkStatus)
-      .then(resp => {
-        this.notifyKeys("updated");
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          this.notifyKeys("updated");
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   getActivation(devEUI, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.GetActivation({
-        "dev_eui": devEUI,
+        dev_eui: devEUI,
       })
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandlerIgnoreNotFoundWithCallback(callbackFunc));
+        .then(checkStatus)
+        .then((resp) => {
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandlerIgnoreNotFoundWithCallback(callbackFunc));
     });
   }
 
   activate(deviceActivation, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.Activate({
         "device_activation.dev_eui": deviceActivation.devEUI,
         body: {
           deviceActivation: deviceActivation,
         },
       })
-      .then(checkStatus)
-      .then(resp => {
-        dispatcher.dispatch({
-          type: "CREATE_NOTIFICATION",
-          notification: {
-            type: "success",
-            message: "device has been (re)activated",
-          },
-        });
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          dispatcher.dispatch({
+            type: "CREATE_NOTIFICATION",
+            notification: {
+              type: "success",
+              message: "device has been (re)activated",
+            },
+          });
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   getRandomDevAddr(devEUI, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.GetRandomDevAddr({
         dev_eui: devEUI,
       })
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
-      })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
   getStats(devEUI, start, end, callbackFunc) {
-    this.swagger.then(client => {
+    this.swagger.then((client) => {
       client.apis.DeviceService.GetStats({
         dev_eui: devEUI,
         interval: "DAY",
         startTimestamp: start,
         endTimestamp: end,
       })
-      .then(checkStatus)
-      .then(resp => {
-        callbackFunc(resp.obj);
+        .then(checkStatus)
+        .then((resp) => {
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
+    });
+  }
+
+  clearDevNonces(id, callbackFunc) {
+    this.swagger.then((client) => {
+      client.apis.DeviceService.ClearDeviceNonces({
+        dev_eui: id,
       })
-      .catch(errorHandler);
+        .then(checkStatus)
+        .then((resp) => {
+          this.notifyMsg("device devNonce deleted");
+          callbackFunc(resp.obj);
+        })
+        .catch(errorHandler);
     });
   }
 
@@ -223,7 +235,7 @@ class DeviceStore extends EventEmitter {
     const conn = new RobustWebSocket(wsURL, ["Bearer", sessionStore.getToken()], {});
 
     conn.addEventListener("open", () => {
-      console.log('connected to', wsURL);
+      console.log("connected to", wsURL);
       this.wsDataStatus = "CONNECTED";
       this.emit("ws.status.change");
     });
@@ -244,7 +256,7 @@ class DeviceStore extends EventEmitter {
     });
 
     conn.addEventListener("close", () => {
-      console.log('closing', wsURL);
+      console.log("closing", wsURL);
       this.wsDataStatus = null;
       this.emit("ws.status.change");
     });
@@ -272,7 +284,7 @@ class DeviceStore extends EventEmitter {
     const conn = new RobustWebSocket(wsURL, ["Bearer", sessionStore.getToken()], {});
 
     conn.addEventListener("open", () => {
-      console.log('connected to', wsURL);
+      console.log("connected to", wsURL);
       this.wsFramesStatus = "CONNECTED";
       this.emit("ws.status.change");
     });
@@ -293,7 +305,7 @@ class DeviceStore extends EventEmitter {
     });
 
     conn.addEventListener("close", () => {
-      console.log('closing', wsURL);
+      console.log("closing", wsURL);
       this.wsFramesStatus = null;
       this.emit("ws.status.change");
     });
@@ -323,6 +335,16 @@ class DeviceStore extends EventEmitter {
       notification: {
         type: "success",
         message: "device-keys have been " + action,
+      },
+    });
+  }
+
+  notifyMsg(action) {
+    dispatcher.dispatch({
+      type: "CREATE_NOTIFICATION",
+      notification: {
+        type: "success",
+        message: action,
       },
     });
   }


### PR DESCRIPTION
Details:
- DevNonce clear functionality helps to remove older device
activation records from device_activation table in NS.
- Using this method we can clear older or already generated device activation
records from database to prevent "DevNonce already exits" error in OTAA method

*Note: Server keeps latest 20 records in device_activation table of NS database
for manage recent device activation.

Signed-off-by: SAGAR PATEL <sagar.a.patel@slscorp.com>