### PR TITLE
[subtle bug] don't delete ping (discovery) lookups from Redis

### DIFF
--- a/internal/gwping/gwping.go
+++ b/internal/gwping/gwping.go
@@ -53,10 +53,6 @@ func HandleReceivedPing(ctx context.Context, req *as.HandleProprietaryUplinkRequ
 		return errors.Wrap(err, "get ping lookup error")
 	}
 
-	if err = deletePingLookup(mic); err != nil {
-		log.Errorf("delete ping lookup error: %s", err)
-	}
-
 	ping, err := storage.GetGatewayPing(ctx, storage.DB(), id)
 	if err != nil {
 		return errors.Wrap(err, "get gateway ping error")
@@ -239,15 +235,4 @@ func getPingLookup(mic lorawan.MIC) (int64, error) {
 	}
 
 	return id, nil
-}
-
-func deletePingLookup(mic lorawan.MIC) error {
-	key := storage.GetRedisKey(micLookupTempl, mic)
-
-	err := storage.RedisClient().Del(context.Background(), key).Err()
-	if err != nil {
-		return errors.Wrap(err, "delete ping lookup error")
-	}
-
-	return nil
 }


### PR DESCRIPTION
There is sublte issue with gateway discovery pings processing. When gateway sends responses for the ping, response includes the "self-ping". It is skipped later, however if response comes in more than single packet, then such "self-ping" causes deletion of ping lookup record from Redis.

Next moment another response may come with "peer-ping" response, but it only founds that lookup can't find ping data anymore and drops queer error:

     ping lookup error: redis: nil

My understanding is that it would be ok not to remove ping lookup records manually, they are anyway set to expire in 10 seconds. Hence it should be ok to remove these two fragments.