### PR TITLE
Fix gw ping frq

### DIFF
--- a/internal/gwping/gwping.go
+++ b/internal/gwping/gwping.go
@@ -180,7 +180,7 @@ func getGatewayForPing(tx sqlx.Ext) (*storage.Gateway, error) {
 			ns.gateway_discovery_enabled = true
 			and g.ping = true
 			and (g.last_ping_sent_at is null or g.last_ping_sent_at <= (now() - (interval '24 hours' / ns.gateway_discovery_interval)))
-		order by last_ping_sent_at
+		order by last_ping_sent_at nulls first
 		limit 1
 		for update`,
 	)

--- a/internal/storage/migrations/0061_gw_discovery_frequency_bigint.down.sql
+++ b/internal/storage/migrations/0061_gw_discovery_frequency_bigint.down.sql
@@ -1,0 +1,2 @@
+alter table network_server
+    alter column gateway_discovery_tx_frequency type integer;

--- a/internal/storage/migrations/0061_gw_discovery_frequency_bigint.down.sql
+++ b/internal/storage/migrations/0061_gw_discovery_frequency_bigint.down.sql
@@ -1,2 +1,4 @@
 alter table network_server
     alter column gateway_discovery_tx_frequency type integer;
+alter table gateway_ping
+    alter column frequency type integer;

--- a/internal/storage/migrations/0061_gw_discovery_frequency_bigint.up.sql
+++ b/internal/storage/migrations/0061_gw_discovery_frequency_bigint.up.sql
@@ -1,0 +1,2 @@
+alter table network_server
+    alter column gateway_discovery_tx_frequency type bigint;

--- a/internal/storage/migrations/0061_gw_discovery_frequency_bigint.up.sql
+++ b/internal/storage/migrations/0061_gw_discovery_frequency_bigint.up.sql
@@ -1,2 +1,4 @@
 alter table network_server
     alter column gateway_discovery_tx_frequency type bigint;
+alter table gateway_ping
+    alter column frequency type bigint;


### PR DESCRIPTION
When trying to enter frequency for GateWay Ping in 2.4 GHz band, it fails with message like `pq: integer out of range`. Looks like simplest way is to alter column type in database.