### PR TITLE
Introduce use_userinfo and assume_email_verified options for OIDC

### DIFF
--- a/cmd/chirpstack-application-server/cmd/configfile.go
+++ b/cmd/chirpstack-application-server/cmd/configfile.go
@@ -207,6 +207,20 @@ id="{{ .ApplicationServer.ID }}"
     # The login label is used in the web-interface login form.
     login_label="{{ .ApplicationServer.UserAuthentication.OpenIDConnect.LoginLabel }}"
 
+    # Use UserInfo.
+    #
+    # Use a UserInfo call to retrieve the claim rather than extracting the claim from
+    # the idToken.
+    use_userinfo="{{ .ApplicationServer.UserAuthentication.OpenIDConnect.UseUserInfo }}"
+
+    # Assume email_verified.
+    #
+    # Assume that the email_verified field is always true, regardless of whether it
+    # is included in the token.
+    #
+    # This is required for identity providers that don't supply this claim, such as
+    # Microsoft Azure AD.
+    use_userinfo="{{ .ApplicationServer.UserAuthentication.OpenIDConnect.AssumeEmailVerified }}"
 
   # JavaScript codec settings.
   [application_server.codec.js]

--- a/cmd/chirpstack-application-server/cmd/configfile.go
+++ b/cmd/chirpstack-application-server/cmd/configfile.go
@@ -211,7 +211,7 @@ id="{{ .ApplicationServer.ID }}"
     #
     # Use a UserInfo call to retrieve the claim rather than extracting the claim from
     # the idToken.
-    use_userinfo="{{ .ApplicationServer.UserAuthentication.OpenIDConnect.UseUserInfo }}"
+    use_userinfo={{ .ApplicationServer.UserAuthentication.OpenIDConnect.UseUserInfo }}
 
     # Assume email_verified.
     #
@@ -220,7 +220,7 @@ id="{{ .ApplicationServer.ID }}"
     #
     # This is required for identity providers that don't supply this claim, such as
     # Microsoft Azure AD.
-    use_userinfo="{{ .ApplicationServer.UserAuthentication.OpenIDConnect.AssumeEmailVerified }}"
+    assume_email_verified={{ .ApplicationServer.UserAuthentication.OpenIDConnect.AssumeEmailVerified }}
 
   # JavaScript codec settings.
   [application_server.codec.js]

--- a/cmd/chirpstack-application-server/cmd/root.go
+++ b/cmd/chirpstack-application-server/cmd/root.go
@@ -65,6 +65,8 @@ func init() {
 	viper.SetDefault("application_server.integration.amqp.event_routing_key_template", "application.{{ .ApplicationID }}.device.{{ .DevEUI }}.event.{{ .EventType }}")
 	viper.SetDefault("application_server.integration.enabled", []string{"mqtt"})
 	viper.SetDefault("application_server.codec.js.max_execution_time", 100*time.Millisecond)
+	viper.SetDefault("application_server.user_authentication.openid_connect.use_userinfo", true)
+	viper.SetDefault("application_server.user_authentication.openid_connect.assume_email_verified", false)
 
 	viper.SetDefault("metrics.timezone", "Local")
 	viper.SetDefault("metrics.redis.aggregation_intervals", []string{"MINUTE", "HOUR", "DAY", "MONTH"})
@@ -72,7 +74,6 @@ func init() {
 	viper.SetDefault("metrics.redis.hour_aggregation_ttl", time.Hour*48)
 	viper.SetDefault("metrics.redis.day_aggregation_ttl", time.Hour*24*90)
 	viper.SetDefault("metrics.redis.month_aggregation_ttl", time.Hour*24*730)
-
 	viper.SetDefault("monitoring.per_device_event_log_max_history", 10)
 
 	rootCmd.AddCommand(versionCmd)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,8 @@ type Config struct {
 				RedirectURL             string `mapstructure:"redirect_url"`
 				LogoutURL               string `mapstructure:"logout_url"`
 				LoginLabel              string `mapstructure:"login_label"`
+				UseUserInfo             bool   `mapstructure:"use_userinfo"`
+				AssumeEmailVerified     bool   `mapstructure:"assume_email_verified"`
 			} `mapstructure:"openid_connect"`
 		} `mapstructure:"user_authentication"`
 


### PR DESCRIPTION
use_userinfo is a configuration option which allows the user to configure
whether OIDC claims should be taken from the ID token (as per the OIDC
design) or whether a separate call should be made to the UserInfo endpoint
in order to take the claim from there. This works around issues with some
identity providers, and prior to this commit, the workaround was permamently
enabled. Set use_userinfo to true in order to preserve this behaviour.

assume_email_verified means that the email_verified claim will always be
assumed to be present and true, regardless of what the identity provider
sends. This is particularly useful for certain providers like Azure AD
which don't normally send the email_verified claim.

Fixes #619 