### PR TITLE
Fix alpine version to prevent nodejs bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine AS development
+FROM golang:1.19.3-alpine3.16 AS development
 
 ENV PROJECT_PATH=/chirpstack-application-server
 ENV PATH=$PATH:$PROJECT_PATH/build

--- a/Dockerfile-devel
+++ b/Dockerfile-devel
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine
+FROM golang:1.19.3-alpine3.16
 
 ENV PROJECT_PATH=/chirpstack-application-server
 ENV PATH=$PATH:$PROJECT_PATH/build


### PR DESCRIPTION
Docker image golang:1.19.3-alpine has moved to nodejs version 18, this contains a breaking change causing the ui/build to fail.
Changed to golang:1.19.3-apline3.16 which still uses nodejs 16.